### PR TITLE
feat: daily / weekly / all-time leaderboard tabs

### DIFF
--- a/src/app/c/[game]/[challenge]/page.tsx
+++ b/src/app/c/[game]/[challenge]/page.tsx
@@ -1,33 +1,27 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { getChallengeLeaderboard, formatFrames } from '@/lib/leaderboard';
+import {
+  getChallengeLeaderboard,
+  formatFrames,
+  parseLeaderboardWindow,
+  type LeaderboardWindow,
+} from '@/lib/leaderboard';
 
 export const dynamic = 'force-dynamic';
 
 interface PageProps {
   params: Promise<{ game: string; challenge: string }>;
+  searchParams: Promise<{ window?: string }>;
 }
 
-export default async function ChallengeLeaderboardPage({ params }: PageProps) {
+export default async function ChallengeLeaderboardPage({ params, searchParams }: PageProps) {
   const { game: gameParam, challenge: challengeParam } = await params;
+  const sp = await searchParams;
   const game = decodeURIComponent(gameParam);
   const challengeName = decodeURIComponent(challengeParam);
+  const activeWindow = parseLeaderboardWindow(sp.window);
 
-  const entries = await getChallengeLeaderboard(game, challengeName, 50);
-
-  if (entries.length === 0) {
-    // Distinguishes "no runs yet" from "nonexistent challenge". We can't
-    // prove a negative without a Challenge table, so both render the
-    // same friendly empty state.
-    return (
-      <div>
-        <Breadcrumb game={game} challengeName={challengeName} />
-        <p className="text-slate-400 mt-8">
-          No runs for this challenge yet. Be the first.
-        </p>
-      </div>
-    );
-  }
+  const entries = await getChallengeLeaderboard(game, challengeName, 50, activeWindow);
 
   return (
     <div>
@@ -36,51 +30,61 @@ export default async function ChallengeLeaderboardPage({ params }: PageProps) {
       <h1 className="font-display text-2xl font-bold text-white mt-2">{challengeName}</h1>
       <p className="text-sm text-slate-400 mb-6">{game}</p>
 
-      <div className="overflow-x-auto">
-        <table className="w-full border-collapse">
-          <thead>
-            <tr className="text-left text-xs uppercase tracking-wider text-slate-500 border-b border-slate-700">
-              <th className="py-2 pr-2 w-12">#</th>
-              <th className="py-2 pr-2">Player</th>
-              <th className="py-2 pr-2 text-right">Score</th>
-              <th className="py-2 pr-2 text-right">Time</th>
-              <th className="py-2 pr-2 text-right hidden sm:table-cell">Submitted</th>
-            </tr>
-          </thead>
-          <tbody>
-            {entries.map((e) => (
-              <tr key={e.runId} className="border-b border-slate-800">
-                <td className="py-2 pr-2 text-slate-500 font-mono">{e.rank}</td>
-                <td className="py-2 pr-2">
-                  <div className="flex items-center gap-2">
-                    {e.userPictureUrl ? (
-                      <Image
-                        src={e.userPictureUrl}
-                        alt=""
-                        width={24}
-                        height={24}
-                        className="rounded-full"
-                      />
-                    ) : (
-                      <div className="w-6 h-6 rounded-full bg-slate-700" aria-hidden="true" />
-                    )}
-                    <span className="text-slate-200">{e.userName}</span>
-                  </div>
-                </td>
-                <td className="py-2 pr-2 text-right font-mono text-slate-200">
-                  {e.score != null ? e.score.toLocaleString() : '—'}
-                </td>
-                <td className="py-2 pr-2 text-right font-mono text-slate-200">
-                  {formatFrames(e.completionTimeFrames)}
-                </td>
-                <td className="py-2 pr-2 text-right text-xs text-slate-500 hidden sm:table-cell">
-                  {new Date(e.serverReceivedAt).toLocaleDateString()}
-                </td>
+      <WindowTabs game={game} challengeName={challengeName} active={activeWindow} />
+
+      {entries.length === 0 ? (
+        <p className="text-slate-400 mt-8">
+          {activeWindow === 'all'
+            ? 'No runs for this challenge yet. Be the first.'
+            : `No runs in the ${activeWindow === 'daily' ? 'last 24 hours' : 'last 7 days'} — try the All Time tab.`}
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wider text-slate-500 border-b border-slate-700">
+                <th className="py-2 pr-2 w-12">#</th>
+                <th className="py-2 pr-2">Player</th>
+                <th className="py-2 pr-2 text-right">Score</th>
+                <th className="py-2 pr-2 text-right">Time</th>
+                <th className="py-2 pr-2 text-right hidden sm:table-cell">Submitted</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody>
+              {entries.map((e) => (
+                <tr key={e.runId} className="border-b border-slate-800">
+                  <td className="py-2 pr-2 text-slate-500 font-mono">{e.rank}</td>
+                  <td className="py-2 pr-2">
+                    <div className="flex items-center gap-2">
+                      {e.userPictureUrl ? (
+                        <Image
+                          src={e.userPictureUrl}
+                          alt=""
+                          width={24}
+                          height={24}
+                          className="rounded-full"
+                        />
+                      ) : (
+                        <div className="w-6 h-6 rounded-full bg-slate-700" aria-hidden="true" />
+                      )}
+                      <span className="text-slate-200">{e.userName}</span>
+                    </div>
+                  </td>
+                  <td className="py-2 pr-2 text-right font-mono text-slate-200">
+                    {e.score != null ? e.score.toLocaleString() : '—'}
+                  </td>
+                  <td className="py-2 pr-2 text-right font-mono text-slate-200">
+                    {formatFrames(e.completionTimeFrames)}
+                  </td>
+                  <td className="py-2 pr-2 text-right text-xs text-slate-500 hidden sm:table-cell">
+                    {new Date(e.serverReceivedAt).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }
@@ -93,6 +97,45 @@ function Breadcrumb({ game, challengeName }: { game: string; challengeName: stri
       <span className="text-slate-400">{game}</span>
       <span className="mx-2">/</span>
       <span className="text-slate-300">{challengeName}</span>
+    </nav>
+  );
+}
+
+function WindowTabs({
+  game,
+  challengeName,
+  active,
+}: {
+  game: string;
+  challengeName: string;
+  active: LeaderboardWindow;
+}) {
+  const tabs: { key: LeaderboardWindow; label: string }[] = [
+    { key: 'daily',  label: 'Daily' },
+    { key: 'weekly', label: 'Weekly' },
+    { key: 'all',    label: 'All Time' },
+  ];
+  const base = `/c/${encodeURIComponent(game)}/${encodeURIComponent(challengeName)}`;
+  return (
+    <nav className="mb-6 inline-flex gap-1 rounded-md border border-slate-700 bg-slate-900 p-1" aria-label="Leaderboard time window">
+      {tabs.map((t) => {
+        const isActive = t.key === active;
+        const href = t.key === 'all' ? base : `${base}?window=${t.key}`;
+        return (
+          <Link
+            key={t.key}
+            href={href}
+            aria-current={isActive ? 'page' : undefined}
+            className={
+              isActive
+                ? 'px-3 py-1 rounded text-sm font-medium bg-indigo-500 text-white'
+                : 'px-3 py-1 rounded text-sm font-medium text-slate-300 hover:bg-slate-800'
+            }
+          >
+            {t.label}
+          </Link>
+        );
+      })}
     </nav>
   );
 }

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -11,7 +11,28 @@ export interface LeaderboardEntry {
   serverReceivedAt: Date;
 }
 
-// Top N rows for a (game, challenge) tuple. Ordering:
+// Time-window keys for the daily / weekly / all-time leaderboard tabs.
+export type LeaderboardWindow = 'daily' | 'weekly' | 'all';
+
+const WINDOW_KEYS: readonly LeaderboardWindow[] = ['daily', 'weekly', 'all'];
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Validate an arbitrary string (e.g. from a URL query param) into a
+// LeaderboardWindow, defaulting to 'all' if it isn't one of the known keys.
+export function parseLeaderboardWindow(value: string | undefined | null): LeaderboardWindow {
+  return WINDOW_KEYS.includes(value as LeaderboardWindow) ? (value as LeaderboardWindow) : 'all';
+}
+
+// Cutoff date for the supplied window. 'all' returns null (no cutoff).
+// Exposed so tests / debugging can reason about it.
+export function windowSince(window: LeaderboardWindow, now: Date = new Date()): Date | null {
+  if (window === 'daily') return new Date(now.getTime() - 1 * DAY_MS);
+  if (window === 'weekly') return new Date(now.getTime() - 7 * DAY_MS);
+  return null;
+}
+
+// Top N rows for a (game, challenge) tuple within an optional time window.
+// Ordering:
 //   1. score DESC (nulls last)   — higher score wins
 //   2. completionTimeFrames ASC  — faster wins ties (and is the primary
 //                                  axis for challenges that have no score)
@@ -20,13 +41,16 @@ export async function getChallengeLeaderboard(
   game: string,
   challengeName: string,
   limit = 50,
+  window: LeaderboardWindow = 'all',
 ): Promise<LeaderboardEntry[]> {
+  const since = windowSince(window);
   const rows = await prisma.run.findMany({
     where: {
       game,
       challengeName,
       hiddenAt: null,
       user: { bannedAt: null },
+      ...(since ? { serverReceivedAt: { gte: since } } : {}),
     },
     orderBy: [
       { score: { sort: 'desc', nulls: 'last' } },

--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -1,4 +1,4 @@
-import { formatFrames, challengeHref } from '../src/lib/leaderboard';
+import { formatFrames, challengeHref, parseLeaderboardWindow, windowSince } from '../src/lib/leaderboard';
 
 describe('formatFrames', () => {
   test('returns em-dash for null', () => {
@@ -34,5 +34,38 @@ describe('challengeHref', () => {
     const name = 'Level 1/2 warp';
     const href = challengeHref('Super Mario Bros', name);
     expect(href.includes('%2F')).toBe(true);
+  });
+});
+
+describe('parseLeaderboardWindow', () => {
+  test('passes through valid window keys', () => {
+    expect(parseLeaderboardWindow('daily')).toBe('daily');
+    expect(parseLeaderboardWindow('weekly')).toBe('weekly');
+    expect(parseLeaderboardWindow('all')).toBe('all');
+  });
+
+  test('falls back to "all" for unknown / missing values', () => {
+    expect(parseLeaderboardWindow(undefined)).toBe('all');
+    expect(parseLeaderboardWindow(null)).toBe('all');
+    expect(parseLeaderboardWindow('')).toBe('all');
+    expect(parseLeaderboardWindow('forever')).toBe('all');
+  });
+});
+
+describe('windowSince', () => {
+  const now = new Date('2026-04-26T12:00:00Z');
+
+  test('returns null for "all" so the query gets no time filter', () => {
+    expect(windowSince('all', now)).toBeNull();
+  });
+
+  test('"daily" cutoff is exactly 24h before now', () => {
+    const cutoff = windowSince('daily', now);
+    expect(cutoff).toEqual(new Date('2026-04-25T12:00:00Z'));
+  });
+
+  test('"weekly" cutoff is exactly 7 days before now', () => {
+    const cutoff = windowSince('weekly', now);
+    expect(cutoff).toEqual(new Date('2026-04-19T12:00:00Z'));
   });
 });


### PR DESCRIPTION
Per-challenge leaderboard page gains Daily / Weekly / All Time tabs (URL: `?window=daily|weekly|all`). Filters by `serverReceivedAt` cutoff; sort order unchanged. New helpers `parseLeaderboardWindow` and `windowSince` are exposed and tested. 12/12 tests, clean build.