### PR TITLE
feat: detect personal-best on submission and return it from POST /api/runs

### DIFF
--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/db';
 import { verifySubmissionSecret } from '@/lib/auth';
+import { isBetterRun } from '@/lib/leaderboard';
 
 // Runtime schema for the submission payload. Matches the shape written
 // by RC.report_completion + the caller-supplied user identity pulled
@@ -73,6 +74,23 @@ export async function POST(req: NextRequest) {
       },
     });
 
+    // Look up the user's previous best on this challenge BEFORE the
+    // insert so the new run isn't compared against itself. Same sort
+    // order the public leaderboard uses.
+    const priorBestRow = await prisma.run.findFirst({
+      where: {
+        userId: user.id,
+        game: s.game,
+        challengeName: s.challengeName,
+        hiddenAt: null,
+      },
+      orderBy: [
+        { score: { sort: 'desc', nulls: 'last' } },
+        { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
+      ],
+      select: { score: true, completionTimeFrames: true },
+    });
+
     const run = await prisma.run.create({
       data: {
         userId: user.id,
@@ -85,7 +103,21 @@ export async function POST(req: NextRequest) {
       },
     });
 
-    return NextResponse.json({ ok: true, runId: run.id }, { status: 201 });
+    // First-ever run for this (user, challenge) is always a personal best.
+    const personalBest = !priorBestRow || isBetterRun(
+      { score: run.score, completionTimeFrames: run.completionTimeFrames },
+      priorBestRow,
+    );
+
+    return NextResponse.json(
+      {
+        ok: true,
+        runId: run.id,
+        personalBest,
+        previousBest: priorBestRow,
+      },
+      { status: 201 },
+    );
   } catch (err) {
     console.error('Failed to record run:', err);
     return NextResponse.json({ error: 'server_error' }, { status: 500 });

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -193,6 +193,23 @@ export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
   }));
 }
 
+// Compare two run metric pairs using the same rule the leaderboard uses
+// for sorting: higher score wins; on a score tie (or both score-less),
+// lower completionTimeFrames wins. Returns true when `a` is strictly
+// better than `b`. Exposed so it's testable.
+export interface RunMetric {
+  score: number | null;
+  completionTimeFrames: number | null;
+}
+export function isBetterRun(a: RunMetric, b: RunMetric): boolean {
+  const as = a.score ?? -Infinity;
+  const bs = b.score ?? -Infinity;
+  if (as !== bs) return as > bs;
+  const at = a.completionTimeFrames ?? Infinity;
+  const bt = b.completionTimeFrames ?? Infinity;
+  return at < bt;
+}
+
 // Rough relative-time string ("12m ago") for activity feed entries.
 // We avoid pulling in a date lib for one helper.
 export function formatRelative(date: Date, now: Date = new Date()): string {

--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -1,4 +1,10 @@
-import { formatFrames, challengeHref, parseLeaderboardWindow, windowSince } from '../src/lib/leaderboard';
+import {
+  formatFrames,
+  challengeHref,
+  parseLeaderboardWindow,
+  windowSince,
+  isBetterRun,
+} from '../src/lib/leaderboard';
 
 describe('formatFrames', () => {
   test('returns em-dash for null', () => {
@@ -49,6 +55,35 @@ describe('parseLeaderboardWindow', () => {
     expect(parseLeaderboardWindow(null)).toBe('all');
     expect(parseLeaderboardWindow('')).toBe('all');
     expect(parseLeaderboardWindow('forever')).toBe('all');
+  });
+});
+
+describe('isBetterRun', () => {
+  test('higher score is better', () => {
+    expect(isBetterRun({ score: 5900, completionTimeFrames: 100 },
+                       { score: 5000, completionTimeFrames: 50 })).toBe(true);
+  });
+  test('on score tie, faster time is better', () => {
+    expect(isBetterRun({ score: 5000, completionTimeFrames: 50 },
+                       { score: 5000, completionTimeFrames: 100 })).toBe(true);
+  });
+  test('on score tie, slower time is not better', () => {
+    expect(isBetterRun({ score: 5000, completionTimeFrames: 200 },
+                       { score: 5000, completionTimeFrames: 100 })).toBe(false);
+  });
+  test('any score beats null score', () => {
+    expect(isBetterRun({ score: 1, completionTimeFrames: null },
+                       { score: null, completionTimeFrames: 5 })).toBe(true);
+    expect(isBetterRun({ score: null, completionTimeFrames: 5 },
+                       { score: 1, completionTimeFrames: null })).toBe(false);
+  });
+  test('time-only challenges: faster wins', () => {
+    expect(isBetterRun({ score: null, completionTimeFrames: 100 },
+                       { score: null, completionTimeFrames: 200 })).toBe(true);
+  });
+  test('exact tie is not strictly better', () => {
+    expect(isBetterRun({ score: 5000, completionTimeFrames: 100 },
+                       { score: 5000, completionTimeFrames: 100 })).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #6. POST /api/runs now returns `personalBest: bool` and `previousBest: { score, completionTimeFrames } | null`. Comparison uses the same rule as the leaderboard sort (`isBetterRun`). 18/18 tests, build clean. Desktop-side surfacing tracked as heliacode/RetroChallenges#37.