### PR TITLE
feat: user profile pages at /u/[userId]

### DIFF
--- a/src/app/c/[game]/[challenge]/page.tsx
+++ b/src/app/c/[game]/[challenge]/page.tsx
@@ -4,6 +4,7 @@ import {
   getChallengeLeaderboard,
   formatFrames,
   parseLeaderboardWindow,
+  userProfileHref,
   type LeaderboardWindow,
 } from '@/lib/leaderboard';
 
@@ -55,7 +56,10 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
                 <tr key={e.runId} className="border-b border-slate-800">
                   <td className="py-2 pr-2 text-slate-500 font-mono">{e.rank}</td>
                   <td className="py-2 pr-2">
-                    <div className="flex items-center gap-2">
+                    <Link
+                      href={userProfileHref(e.userId)}
+                      className="flex items-center gap-2 group"
+                    >
                       {e.userPictureUrl ? (
                         <Image
                           src={e.userPictureUrl}
@@ -67,8 +71,8 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
                       ) : (
                         <div className="w-6 h-6 rounded-full bg-slate-700" aria-hidden="true" />
                       )}
-                      <span className="text-slate-200">{e.userName}</span>
-                    </div>
+                      <span className="text-slate-200 group-hover:text-indigo-300">{e.userName}</span>
+                    </Link>
                   </td>
                   <td className="py-2 pr-2 text-right font-mono text-slate-200">
                     {e.score != null ? e.score.toLocaleString() : '—'}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import {
   getOverallStats,
   getRecentRuns,
   listChallengeSummaries,
+  userProfileHref,
   type ChallengeSummary,
   type RecentRunEntry,
 } from '@/lib/leaderboard';
@@ -136,6 +137,10 @@ function ChallengeCard({ summary }: { summary: ChallengeSummary }) {
           ) : (
             <div className="w-5 h-5 rounded-full bg-slate-700" aria-hidden="true" />
           )}
+          {/* Username inside the card-Link can't be its own Link in valid
+              HTML, so we keep it as plain text here. The whole card already
+              navigates to the challenge; the dedicated profile path is via
+              the username column on the per-challenge leaderboard table. */}
           <span className="text-slate-200 truncate flex-1">{top.userName}</span>
           <span className="font-mono text-slate-300 tabular-nums">
             {formatTopMetric(top.score, top.completionTimeFrames)}
@@ -176,7 +181,12 @@ function RecentActivity({ runs }: { runs: RecentRunEntry[] }) {
             )}
             <div className="min-w-0 flex-1">
               <div className="text-slate-200 truncate">
-                <span className="font-medium">{r.userName}</span>
+                <Link
+                  href={userProfileHref(r.userId)}
+                  className="font-medium hover:text-indigo-300"
+                >
+                  {r.userName}
+                </Link>
                 <span className="text-slate-500"> finished </span>
                 <Link
                   href={challengeHref(r.game, r.challengeName)}

--- a/src/app/u/[userId]/page.tsx
+++ b/src/app/u/[userId]/page.tsx
@@ -1,0 +1,128 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import {
+  challengeHref,
+  formatFrames,
+  getUserProfile,
+  type UserProfile,
+  type UserProfileChallenge,
+} from '@/lib/leaderboard';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: Promise<{ userId: string }>;
+}
+
+export default async function UserProfilePage({ params }: PageProps) {
+  const { userId: userIdParam } = await params;
+  const userId = decodeURIComponent(userIdParam);
+
+  const profile = await getUserProfile(userId);
+  if (!profile) notFound();
+
+  return (
+    <div className="space-y-8">
+      <Hero profile={profile} />
+      {profile.challenges.length === 0 ? (
+        <p className="text-slate-400">
+          No runs yet — once {profile.name} finishes a challenge, it'll appear here.
+        </p>
+      ) : (
+        <ChallengeTable rows={profile.challenges} />
+      )}
+    </div>
+  );
+}
+
+function Hero({ profile }: { profile: UserProfile }) {
+  return (
+    <section className="flex items-center gap-4">
+      {profile.pictureUrl ? (
+        <Image
+          src={profile.pictureUrl}
+          alt=""
+          width={80}
+          height={80}
+          className="rounded-full border border-slate-700"
+        />
+      ) : (
+        <div className="w-20 h-20 rounded-full bg-slate-700" aria-hidden="true" />
+      )}
+      <div className="min-w-0">
+        <nav className="text-sm text-slate-500 mb-1">
+          <Link href="/" className="hover:text-slate-300">Leaderboards</Link>
+          <span className="mx-2">/</span>
+          <span className="text-slate-300">Players</span>
+        </nav>
+        <h1 className="font-display text-3xl font-bold text-white truncate">{profile.name}</h1>
+        <div className="text-sm text-slate-400 mt-1">
+          <span className="font-medium text-slate-200">{profile.totalRuns}</span>
+          <span> total run{profile.totalRuns === 1 ? '' : 's'}</span>
+          <span className="mx-2">&middot;</span>
+          <span>joined {new Date(profile.createdAt).toLocaleDateString()}</span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ChallengeTable({ rows }: { rows: UserProfileChallenge[] }) {
+  return (
+    <section>
+      <h2 className="font-display text-xl font-semibold text-white mb-3">Best on each challenge</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="text-left text-xs uppercase tracking-wider text-slate-500 border-b border-slate-700">
+              <th className="py-2 pr-2">Game</th>
+              <th className="py-2 pr-2">Challenge</th>
+              <th className="py-2 pr-2 text-right">Score</th>
+              <th className="py-2 pr-2 text-right">Time</th>
+              <th className="py-2 pr-2 text-right">Rank</th>
+              <th className="py-2 pr-2 text-right hidden sm:table-cell">Attempts</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={`${r.game}::${r.challengeName}`} className="border-b border-slate-800">
+                <td className="py-2 pr-2 text-slate-200">{r.game}</td>
+                <td className="py-2 pr-2">
+                  <Link
+                    href={challengeHref(r.game, r.challengeName)}
+                    className="text-indigo-300 hover:text-indigo-200"
+                  >
+                    {r.challengeName}
+                  </Link>
+                </td>
+                <td className="py-2 pr-2 text-right font-mono text-slate-200 tabular-nums">
+                  {r.bestRun.score != null ? r.bestRun.score.toLocaleString() : '—'}
+                </td>
+                <td className="py-2 pr-2 text-right font-mono text-slate-200 tabular-nums">
+                  {formatFrames(r.bestRun.completionTimeFrames)}
+                </td>
+                <td className="py-2 pr-2 text-right font-mono">
+                  {r.rank ? <RankBadge rank={r.rank} /> : <span className="text-slate-500">—</span>}
+                </td>
+                <td className="py-2 pr-2 text-right text-slate-500 hidden sm:table-cell">
+                  {r.attempts}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function RankBadge({ rank }: { rank: number }) {
+  // Lean into 1/2/3 with medal-ish colors; everything else is muted.
+  const cls =
+    rank === 1 ? 'text-amber-300 font-semibold' :
+    rank === 2 ? 'text-slate-300 font-medium' :
+    rank === 3 ? 'text-orange-300 font-medium' :
+    'text-slate-400';
+  return <span className={cls}>#{rank}</span>;
+}

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -193,6 +193,111 @@ export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
   }));
 }
 
+// ---------------------------------------------------------------------------
+// User profile data
+// ---------------------------------------------------------------------------
+export interface UserProfile {
+  userId: string;
+  name: string;
+  pictureUrl: string | null;
+  createdAt: Date;
+  totalRuns: number;
+  challenges: UserProfileChallenge[];
+}
+
+// One row per (game, challengeName) the user has runs on.
+export interface UserProfileChallenge {
+  game: string;
+  challengeName: string;
+  attempts: number;
+  bestRun: {
+    runId: string;
+    score: number | null;
+    completionTimeFrames: number | null;
+    serverReceivedAt: Date;
+  };
+  rank: number | null;   // null if we couldn't determine; otherwise 1-based
+}
+
+// Build a UserProfile for /u/<userId>. Rank is computed by counting how many
+// users have a strictly-better best on the same challenge — cheap at our
+// scale (single-digit challenges, low triple-digit users), revisit if either
+// climbs by an order of magnitude.
+export async function getUserProfile(userId: string): Promise<UserProfile | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true, pictureUrl: true, createdAt: true, bannedAt: true },
+  });
+  if (!user || user.bannedAt) return null;
+
+  const userRuns = await prisma.run.findMany({
+    where: { userId, hiddenAt: null },
+    orderBy: [
+      { score: { sort: 'desc', nulls: 'last' } },
+      { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
+    ],
+    select: {
+      id: true,
+      game: true,
+      challengeName: true,
+      score: true,
+      completionTimeFrames: true,
+      serverReceivedAt: true,
+    },
+  });
+
+  // Collapse to one row per (game, challengeName) — the first occurrence
+  // is already the user's best because the orderBy mirrors the leaderboard
+  // sort. Count attempts per challenge for the secondary stat.
+  const byChallenge = new Map<string, { best: typeof userRuns[number]; attempts: number }>();
+  for (const r of userRuns) {
+    const key = `${r.game}::${r.challengeName}`;
+    const existing = byChallenge.get(key);
+    if (!existing) {
+      byChallenge.set(key, { best: r, attempts: 1 });
+    } else {
+      existing.attempts += 1;
+    }
+  }
+
+  const challenges: UserProfileChallenge[] = await Promise.all(
+    Array.from(byChallenge.values()).map(async ({ best, attempts }) => {
+      const top = await getChallengeLeaderboard(best.game, best.challengeName, 100);
+      const idx = top.findIndex((entry) => entry.userId === userId);
+      return {
+        game: best.game,
+        challengeName: best.challengeName,
+        attempts,
+        bestRun: {
+          runId: best.id,
+          score: best.score,
+          completionTimeFrames: best.completionTimeFrames,
+          serverReceivedAt: best.serverReceivedAt,
+        },
+        rank: idx >= 0 ? idx + 1 : null,
+      };
+    }),
+  );
+
+  challenges.sort((a, b) => {
+    if (a.game !== b.game) return a.game.localeCompare(b.game);
+    return a.challengeName.localeCompare(b.challengeName);
+  });
+
+  return {
+    userId: user.id,
+    name: user.name,
+    pictureUrl: user.pictureUrl,
+    createdAt: user.createdAt,
+    totalRuns: userRuns.length,
+    challenges,
+  };
+}
+
+export function userProfileHref(userId: string): string {
+  return `/u/${encodeURIComponent(userId)}`;
+}
+
 // Compare two run metric pairs using the same rule the leaderboard uses
 // for sorting: higher score wins; on a score tie (or both score-less),
 // lower completionTimeFrames wins. Returns true when `a` is strictly


### PR DESCRIPTION
Closes #7. New page showing one player's runs across every challenge they've completed — hero with avatar + totals, then a table of their best run per challenge with current rank and attempt count. Rank 1/2/3 medal-tinted. Linkable from username columns on the per-challenge leaderboards and the home-page activity feed. 18/18 tests, clean build.