### PR TITLE
feat: Discord webhook on top-3 leaderboard placements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,8 @@ SUBMISSION_SECRET=""
 # or fraudulent runs. Keep this in a password manager, not in the binary.
 # Generate with: openssl rand -hex 32
 ADMIN_TOKEN=""
+
+# Optional Discord webhook URL — when set, a top-3 placement on any
+# challenge fires a celebration embed. Leave empty to disable.
+# Discord -> Server Settings -> Integrations -> Webhooks -> New.
+DISCORD_LEADERBOARD_WEBHOOK=""

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/db';
 import { verifySubmissionSecret } from '@/lib/auth';
-import { isBetterRun } from '@/lib/leaderboard';
+import { isBetterRun, getChallengeLeaderboard, challengeHref } from '@/lib/leaderboard';
+import { notifyDiscordTopPlacement } from '@/lib/discord';
 
 // Runtime schema for the submission payload. Matches the shape written
 // by RC.report_completion + the caller-supplied user identity pulled
@@ -108,6 +109,30 @@ export async function POST(req: NextRequest) {
       { score: run.score, completionTimeFrames: run.completionTimeFrames },
       priorBestRow,
     );
+
+    // If the new run lands in the top 3 for the challenge, fire a
+    // Discord webhook (fire-and-forget; won't delay the API response,
+    // never blocks the success path).
+    void (async () => {
+      try {
+        const top3 = await getChallengeLeaderboard(s.game, s.challengeName, 3);
+        const idx = top3.findIndex((entry) => entry.runId === run.id);
+        if (idx === -1) return;  // not top 3, nothing to celebrate
+        const origin = req.nextUrl.origin;
+        await notifyDiscordTopPlacement({
+          rank: idx + 1,
+          playerName: user.name,
+          playerAvatarUrl: user.pictureUrl,
+          game: s.game,
+          challengeName: s.challengeName,
+          score: run.score,
+          completionTimeFrames: run.completionTimeFrames,
+          publicHref: `${origin}${challengeHref(s.game, s.challengeName)}`,
+        });
+      } catch (err) {
+        console.error('top-placement notification failed:', err);
+      }
+    })();
 
     return NextResponse.json(
       {

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -1,0 +1,75 @@
+import { formatFrames } from './leaderboard';
+
+// Discord webhook for celebrating top-3 placements. Configured per-deploy
+// via the DISCORD_LEADERBOARD_WEBHOOK env var on Railway. When unset the
+// fire-and-forget helper is a no-op — no error, no log noise — so local
+// dev and ungated deploys stay quiet.
+
+export interface DiscordTopPlacementPayload {
+  rank: number;        // 1, 2, or 3
+  playerName: string;
+  playerAvatarUrl: string | null;
+  game: string;
+  challengeName: string;
+  score: number | null;
+  completionTimeFrames: number | null;
+  publicHref: string;  // absolute URL to the per-challenge leaderboard
+}
+
+const RANK_COLORS = {
+  1: 0xfbbf24,   // amber-400 — gold
+  2: 0xcbd5e1,   // slate-300 — silver
+  3: 0xfb923c,   // orange-400 — bronze
+} as const;
+
+const RANK_TITLES = {
+  1: '#1 — new top score!',
+  2: '#2 placement',
+  3: '#3 placement',
+} as const;
+
+function describeMetric(score: number | null, frames: number | null): string {
+  if (score != null && frames != null) return `**${score.toLocaleString()}** in ${formatFrames(frames)}`;
+  if (score != null)                   return `**${score.toLocaleString()}**`;
+  if (frames != null)                  return formatFrames(frames);
+  return '—';
+}
+
+// Returns the request promise so callers can .catch — but never reject if
+// the webhook URL isn't configured.
+export async function notifyDiscordTopPlacement(p: DiscordTopPlacementPayload): Promise<void> {
+  const url = process.env.DISCORD_LEADERBOARD_WEBHOOK;
+  if (!url) return;
+  if (p.rank < 1 || p.rank > 3) return;  // we only celebrate top 3
+
+  const title = RANK_TITLES[p.rank as 1 | 2 | 3];
+  const color = RANK_COLORS[p.rank as 1 | 2 | 3];
+
+  const embed: Record<string, unknown> = {
+    title,
+    description: `${p.playerName} just placed on **${p.challengeName}** (${p.game}) with ${describeMetric(p.score, p.completionTimeFrames)}.`,
+    color,
+    url: p.publicHref,
+    timestamp: new Date().toISOString(),
+    footer: { text: 'RetroChallenges leaderboard' },
+  };
+  if (p.playerAvatarUrl) {
+    embed.thumbnail = { url: p.playerAvatarUrl };
+  }
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username: 'RetroChallenges Bot',
+        embeds: [embed],
+      }),
+    });
+    if (!res.ok) {
+      console.error(`Discord webhook responded ${res.status}: ${await res.text().catch(() => '')}`);
+    }
+  } catch (err) {
+    console.error('Discord webhook fetch failed:', err);
+  }
+}


### PR DESCRIPTION
Closes #8. Top-3 placements (or new #1) trigger a Discord webhook embed with the player's avatar, score/time, and a link to the leaderboard. No-op when `DISCORD_LEADERBOARD_WEBHOOK` isn't set. Fire-and-forget — never blocks the API response. 18/18 tests, clean build.