### PR TITLE
feat: best-per-user view on the per-challenge leaderboard

### DIFF
--- a/src/app/c/[game]/[challenge]/page.tsx
+++ b/src/app/c/[game]/[challenge]/page.tsx
@@ -4,15 +4,17 @@ import {
   getChallengeLeaderboard,
   formatFrames,
   parseLeaderboardWindow,
+  parseLeaderboardView,
   userProfileHref,
   type LeaderboardWindow,
+  type LeaderboardView,
 } from '@/lib/leaderboard';
 
 export const dynamic = 'force-dynamic';
 
 interface PageProps {
   params: Promise<{ game: string; challenge: string }>;
-  searchParams: Promise<{ window?: string }>;
+  searchParams: Promise<{ window?: string; view?: string }>;
 }
 
 export default async function ChallengeLeaderboardPage({ params, searchParams }: PageProps) {
@@ -21,8 +23,9 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
   const game = decodeURIComponent(gameParam);
   const challengeName = decodeURIComponent(challengeParam);
   const activeWindow = parseLeaderboardWindow(sp.window);
+  const activeView = parseLeaderboardView(sp.view);
 
-  const entries = await getChallengeLeaderboard(game, challengeName, 50, activeWindow);
+  const entries = await getChallengeLeaderboard(game, challengeName, 50, activeWindow, activeView);
 
   return (
     <div>
@@ -31,7 +34,10 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
       <h1 className="font-display text-2xl font-bold text-white mt-2">{challengeName}</h1>
       <p className="text-sm text-slate-400 mb-6">{game}</p>
 
-      <WindowTabs game={game} challengeName={challengeName} active={activeWindow} />
+      <div className="flex flex-wrap items-center gap-3 mb-6">
+        <WindowTabs game={game} challengeName={challengeName} activeWindow={activeWindow} activeView={activeView} />
+        <ViewToggle game={game} challengeName={challengeName} activeWindow={activeWindow} activeView={activeView} />
+      </div>
 
       {entries.length === 0 ? (
         <p className="text-slate-400 mt-8">
@@ -105,30 +111,86 @@ function Breadcrumb({ game, challengeName }: { game: string; challengeName: stri
   );
 }
 
+// Build a /c/<game>/<challenge>?... URL preserving the non-default of
+// either selector — drops keys when they're at their default to keep
+// shared URLs short.
+function buildHref(
+  game: string,
+  challengeName: string,
+  window: LeaderboardWindow,
+  view: LeaderboardView,
+): string {
+  const base = `/c/${encodeURIComponent(game)}/${encodeURIComponent(challengeName)}`;
+  const params: string[] = [];
+  if (window !== 'all') params.push(`window=${window}`);
+  if (view !== 'best') params.push(`view=${view}`);
+  return params.length === 0 ? base : `${base}?${params.join('&')}`;
+}
+
 function WindowTabs({
   game,
   challengeName,
-  active,
+  activeWindow,
+  activeView,
 }: {
   game: string;
   challengeName: string;
-  active: LeaderboardWindow;
+  activeWindow: LeaderboardWindow;
+  activeView: LeaderboardView;
 }) {
   const tabs: { key: LeaderboardWindow; label: string }[] = [
     { key: 'daily',  label: 'Daily' },
     { key: 'weekly', label: 'Weekly' },
     { key: 'all',    label: 'All Time' },
   ];
-  const base = `/c/${encodeURIComponent(game)}/${encodeURIComponent(challengeName)}`;
   return (
-    <nav className="mb-6 inline-flex gap-1 rounded-md border border-slate-700 bg-slate-900 p-1" aria-label="Leaderboard time window">
+    <nav className="inline-flex gap-1 rounded-md border border-slate-700 bg-slate-900 p-1" aria-label="Leaderboard time window">
       {tabs.map((t) => {
-        const isActive = t.key === active;
-        const href = t.key === 'all' ? base : `${base}?window=${t.key}`;
+        const isActive = t.key === activeWindow;
         return (
           <Link
             key={t.key}
-            href={href}
+            href={buildHref(game, challengeName, t.key, activeView)}
+            aria-current={isActive ? 'page' : undefined}
+            className={
+              isActive
+                ? 'px-3 py-1 rounded text-sm font-medium bg-indigo-500 text-white'
+                : 'px-3 py-1 rounded text-sm font-medium text-slate-300 hover:bg-slate-800'
+            }
+          >
+            {t.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+// Toggle between "best per user" (one row each) and "all attempts"
+// (every run, with possible duplicates from the same player).
+function ViewToggle({
+  game,
+  challengeName,
+  activeWindow,
+  activeView,
+}: {
+  game: string;
+  challengeName: string;
+  activeWindow: LeaderboardWindow;
+  activeView: LeaderboardView;
+}) {
+  const tabs: { key: LeaderboardView; label: string }[] = [
+    { key: 'best', label: 'Best per player' },
+    { key: 'all',  label: 'All attempts' },
+  ];
+  return (
+    <nav className="inline-flex gap-1 rounded-md border border-slate-700 bg-slate-900 p-1" aria-label="Leaderboard row mode">
+      {tabs.map((t) => {
+        const isActive = t.key === activeView;
+        return (
+          <Link
+            key={t.key}
+            href={buildHref(game, challengeName, activeWindow, t.key)}
             aria-current={isActive ? 'page' : undefined}
             className={
               isActive

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -23,6 +23,16 @@ export function parseLeaderboardWindow(value: string | undefined | null): Leader
   return WINDOW_KEYS.includes(value as LeaderboardWindow) ? (value as LeaderboardWindow) : 'all';
 }
 
+// View modes for the per-challenge leaderboard:
+//   'best'    — one row per player, showing their best run (default)
+//   'all'     — every run, including multiple by the same player
+export type LeaderboardView = 'best' | 'all';
+
+const VIEW_KEYS: readonly LeaderboardView[] = ['best', 'all'];
+export function parseLeaderboardView(value: string | undefined | null): LeaderboardView {
+  return VIEW_KEYS.includes(value as LeaderboardView) ? (value as LeaderboardView) : 'best';
+}
+
 // Cutoff date for the supplied window. 'all' returns null (no cutoff).
 // Exposed so tests / debugging can reason about it.
 export function windowSince(window: LeaderboardWindow, now: Date = new Date()): Date | null {
@@ -37,41 +47,82 @@ export function windowSince(window: LeaderboardWindow, now: Date = new Date()): 
 //   2. completionTimeFrames ASC  — faster wins ties (and is the primary
 //                                  axis for challenges that have no score)
 //   3. serverReceivedAt ASC      — whoever posted first breaks the final tie
+//
+// view='best' (default) collapses to one row per user (their best run).
+// view='all' shows every run including duplicates from the same user.
 export async function getChallengeLeaderboard(
   game: string,
   challengeName: string,
   limit = 50,
   window: LeaderboardWindow = 'all',
+  view: LeaderboardView = 'best',
 ): Promise<LeaderboardEntry[]> {
   const since = windowSince(window);
-  const rows = await prisma.run.findMany({
-    where: {
-      game,
-      challengeName,
-      hiddenAt: null,
-      user: { bannedAt: null },
-      ...(since ? { serverReceivedAt: { gte: since } } : {}),
+  const baseWhere = {
+    game,
+    challengeName,
+    hiddenAt: null,
+    user: { bannedAt: null },
+    ...(since ? { serverReceivedAt: { gte: since } } : {}),
+  };
+  const baseSelect = {
+    id: true,
+    score: true,
+    completionTimeFrames: true,
+    serverReceivedAt: true,
+    user: {
+      select: { id: true, name: true, pictureUrl: true },
     },
-    orderBy: [
-      { score: { sort: 'desc', nulls: 'last' } },
-      { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
-      { serverReceivedAt: 'asc' },
-    ],
-    take: limit,
-    select: {
-      id: true,
-      score: true,
-      completionTimeFrames: true,
-      serverReceivedAt: true,
-      user: {
-        select: {
-          id: true,
-          name: true,
-          pictureUrl: true,
-        },
-      },
-    },
-  });
+  } as const;
+
+  type RawRow = {
+    id: string;
+    score: number | null;
+    completionTimeFrames: number | null;
+    serverReceivedAt: Date;
+    user: { id: string; name: string; pictureUrl: string | null };
+  };
+
+  let rows: RawRow[];
+
+  if (view === 'best') {
+    // DISTINCT ON userId — Prisma requires the distinct field to lead the
+    // orderBy, so we order by userId first to satisfy Postgres, then by
+    // the leaderboard sort to pick each user's best row. Result is
+    // ordered by userId; we re-sort into leaderboard order in JS and
+    // slice to the limit.
+    const dedup = await prisma.run.findMany({
+      where: baseWhere,
+      distinct: ['userId'],
+      orderBy: [
+        { userId: 'asc' },
+        { score: { sort: 'desc', nulls: 'last' } },
+        { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
+      ],
+      select: baseSelect,
+    });
+    dedup.sort((a, b) => {
+      const as = a.score ?? -Infinity;
+      const bs = b.score ?? -Infinity;
+      if (as !== bs) return bs - as;
+      const at = a.completionTimeFrames ?? Infinity;
+      const bt = b.completionTimeFrames ?? Infinity;
+      if (at !== bt) return at - bt;
+      return a.serverReceivedAt.getTime() - b.serverReceivedAt.getTime();
+    });
+    rows = dedup.slice(0, limit);
+  } else {
+    rows = await prisma.run.findMany({
+      where: baseWhere,
+      orderBy: [
+        { score: { sort: 'desc', nulls: 'last' } },
+        { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
+        { serverReceivedAt: 'asc' },
+      ],
+      take: limit,
+      select: baseSelect,
+    });
+  }
 
   return rows.map((r, idx) => ({
     runId: r.id,

--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -2,6 +2,7 @@ import {
   formatFrames,
   challengeHref,
   parseLeaderboardWindow,
+  parseLeaderboardView,
   windowSince,
   isBetterRun,
 } from '../src/lib/leaderboard';
@@ -55,6 +56,19 @@ describe('parseLeaderboardWindow', () => {
     expect(parseLeaderboardWindow(null)).toBe('all');
     expect(parseLeaderboardWindow('')).toBe('all');
     expect(parseLeaderboardWindow('forever')).toBe('all');
+  });
+});
+
+describe('parseLeaderboardView', () => {
+  test('passes through valid view keys', () => {
+    expect(parseLeaderboardView('best')).toBe('best');
+    expect(parseLeaderboardView('all')).toBe('all');
+  });
+  test('falls back to "best" for unknown / missing values', () => {
+    expect(parseLeaderboardView(undefined)).toBe('best');
+    expect(parseLeaderboardView(null)).toBe('best');
+    expect(parseLeaderboardView('')).toBe('best');
+    expect(parseLeaderboardView('weekly')).toBe('best');
   });
 });
 


### PR DESCRIPTION
Default per-challenge view is now "Best per player" — one row per user, their best run. Toggle for "All attempts" preserves the previous behaviour. Time-window tabs (Daily/Weekly/All Time) and the new view toggle preserve each other's state on navigation. Postgres DISTINCT ON via Prisma's `distinct` clause; re-sort in JS into leaderboard order and slice to limit. 20/20 tests, build clean.