### PR TITLE
feat(api): user-profile JSON endpoints

### DIFF
--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getUserProfile } from '@/lib/leaderboard';
+
+export const runtime = 'nodejs';
+
+// Returns the same UserProfile the SSR /u/[userId] page renders,
+// as JSON. Public endpoint (matches the page's visibility) — no
+// secret required.
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const profile = await getUserProfile(id);
+  if (!profile) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+  return NextResponse.json(profile);
+}

--- a/src/app/api/users/by-google-sub/[sub]/route.ts
+++ b/src/app/api/users/by-google-sub/[sub]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { getUserProfile } from '@/lib/leaderboard';
+
+export const runtime = 'nodejs';
+
+// Profile lookup by Google `sub` claim — what the desktop app
+// has on hand from its sign-in (state.userInfo.googleSub). Saves
+// the client from an extra round-trip just to translate sub -> uuid.
+// Public; no secret required.
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ sub: string }> }) {
+  const { sub } = await params;
+  const user = await prisma.user.findUnique({ where: { googleSub: sub }, select: { id: true } });
+  if (!user) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+  const profile = await getUserProfile(user.id);
+  if (!profile) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+  return NextResponse.json(profile);
+}


### PR DESCRIPTION
Two GET routes returning the same UserProfile the /u/[userId] SSR page already renders. Public (matches the page). The desktop app needs the by-google-sub variant since it has the sub claim from sign-in but not our internal uuid.