### PR TITLE
feat: rebrand leaderboard to FlawlessNes + NES palette

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,7 +13,7 @@
 }
 
 :focus-visible {
-  outline: 2px solid #60a5fa;
+  outline: 2px solid #E40058;
   outline-offset: 2px;
   border-radius: 4px;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,8 @@ import Link from 'next/link';
 import './globals.css';
 
 export const metadata: Metadata = {
-  title: 'RetroChallenges Leaderboard',
-  description: 'Community leaderboards for RetroChallenges — retro gaming challenges with verified completions.',
+  title: 'FlawlessNes Leaderboard',
+  description: 'Community leaderboards for FlawlessNes — retro gaming challenges with verified completions.',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -22,7 +22,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <header className="border-b border-slate-700 bg-slate-900/80 backdrop-blur sticky top-0 z-10">
           <div className="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
             <Link href="/" className="font-display text-xl font-bold text-white">
-              Retro Challenges
+              FlawlessNes
             </Link>
             <nav className="text-sm text-slate-400">
               <span>Leaderboards</span>
@@ -33,7 +33,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <main className="max-w-5xl mx-auto px-4 py-8">{children}</main>
 
         <footer className="border-t border-slate-700 mt-16 py-6 text-center text-xs text-slate-500">
-          <span>&copy; 2026 Retro Challenges</span>
+          <span>&copy; 2026 FlawlessNes</span>
         </footer>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,7 +29,7 @@ export default async function HomePage() {
       {summaries.length === 0 ? (
         <section className="rounded-lg border border-dashed border-slate-700 p-8 text-center">
           <p className="text-slate-400">
-            No runs submitted yet. Be the first — open the RetroChallenges app and beat a challenge.
+            No runs submitted yet. Be the first — open the FlawlessNes app and beat a challenge.
           </p>
         </section>
       ) : (
@@ -51,7 +51,7 @@ function Hero({ stats }: { stats: { totalRuns: number; totalPlayers: number; tot
     <section>
       <h1 className="font-display text-3xl font-bold text-white mb-2">Leaderboards</h1>
       <p className="text-slate-400 mb-5">
-        Community-submitted runs from the RetroChallenges desktop app. Every row is a verified
+        Community-submitted runs from the FlawlessNes desktop app. Every row is a verified
         in-emulator completion — scores land here the moment the challenge pings complete.
       </p>
       <dl className="grid grid-cols-3 gap-3 sm:max-w-md">

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -51,7 +51,7 @@ export async function notifyDiscordTopPlacement(p: DiscordTopPlacementPayload): 
     color,
     url: p.publicHref,
     timestamp: new Date().toISOString(),
-    footer: { text: 'RetroChallenges leaderboard' },
+    footer: { text: 'FlawlessNes leaderboard' },
   };
   if (p.playerAvatarUrl) {
     embed.thumbnail = { url: p.playerAvatarUrl };
@@ -62,7 +62,7 @@ export async function notifyDiscordTopPlacement(p: DiscordTopPlacementPayload): 
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        username: 'RetroChallenges Bot',
+        username: 'FlawlessNes Bot',
         embeds: [embed],
       }),
     });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,10 @@
 import type { Config } from 'tailwindcss';
 
+// NES-restricted palette mirrors the FlawlessNes desktop app: every
+// slate/gray shade collapses to NES grays and every accent palette
+// (indigo/fuchsia/sky/emerald/amber/orange) collapses to a 5-step NES
+// red ramp. Existing Tailwind class names (bg-slate-900, text-indigo-300,
+// etc.) keep working — they just paint NES colours.
 const config: Config = {
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
@@ -9,10 +14,22 @@ const config: Config = {
         sans: ['Inter', 'system-ui', 'sans-serif'],
       },
       colors: {
-        // Mirrors the desktop app's palette so the two products read as one.
         slate: {
-          925: '#0b1322',
+          50:  '#E0E0E0', 100: '#BCBCBC', 200: '#BCBCBC', 300: '#BCBCBC',
+          400: '#7C7C7C', 500: '#545454', 600: '#545454',
+          700: '#3D3D3D', 800: '#2C2C2C', 900: '#1A1A1A', 925: '#0F0F0F', 950: '#0F0F0F',
         },
+        gray: {
+          50:  '#E0E0E0', 100: '#BCBCBC', 200: '#BCBCBC', 300: '#BCBCBC',
+          400: '#7C7C7C', 500: '#545454', 600: '#545454',
+          700: '#3D3D3D', 800: '#2C2C2C', 900: '#1A1A1A',
+        },
+        indigo:  { 100: '#FFB0B0', 200: '#FF8688', 300: '#E40058', 400: '#B53120', 500: '#B53120', 600: '#7E0000', 700: '#7E0000' },
+        fuchsia: { 100: '#FFB0B0', 200: '#FF8688', 300: '#FF6058', 400: '#FF6058', 500: '#E40058', 600: '#B53120' },
+        sky:     { 100: '#FFB0B0', 200: '#E40058', 300: '#B53120', 400: '#B53120', 500: '#7E0000', 600: '#7E0000' },
+        emerald: { 100: '#FFB0B0', 200: '#E40058', 300: '#B53120', 400: '#B53120', 500: '#B53120', 600: '#7E0000' },
+        amber:   { 100: '#FFB0B0', 200: '#FF6058', 300: '#E40058', 400: '#E40058', 500: '#B53120', 600: '#7E0000' },
+        orange:  { 100: '#FFB0B0', 200: '#FF8688', 300: '#E40058', 400: '#B53120', 500: '#B53120', 600: '#7E0000' },
       },
     },
   },


### PR DESCRIPTION
## Summary
Mirrors the desktop app rebrand (heliacode/RetroChallenges#62).

**Brand:**
- Page \`<title>\`, header link, footer copyright, hero copy, empty-state callout, and Discord webhook (footer text + bot username) all read **FlawlessNes**.

**Palette:**
- \`tailwind.config.ts\` remaps slate/gray shades to NES grays and collapses indigo / fuchsia / sky / emerald / amber / orange into a 5-step NES red ramp. Existing class soup keeps working — \`bg-indigo-500\` paints NES red, \`text-amber-300\` paints bright red, etc.
- The custom \`slate-925\` token (the body background) flips to NES near-black (\`#0F0F0F\`).
- \`globals.css\` focus ring goes from blue (\`#60a5fa\`) to bright NES red (\`#E40058\`).

**Intentionally untouched:**
- Repo name, leaderboard URL, package name (\`retrochallenges-leaderboard\`).
- Discord embed rank colors (gold/silver/bronze for top 3) — the medal convention is universal across leaderboards, breaking it would confuse users.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 36/36 passing
- [ ] \`npm run dev\` — visual smoke test, header reads "FlawlessNes", body bg is near-black, accents are red
- [ ] Submit a run from the desktop app — verify Discord webhook posts as "FlawlessNes Bot"

🤖 Generated with [Claude Code](https://claude.com/claude-code)