### PR TITLE
feat(nav): phase 1 — game-first browse hub

### DIFF
--- a/src/app/c/[game]/[challenge]/page.tsx
+++ b/src/app/c/[game]/[challenge]/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import {
+  gameHref,
   getChallengeLeaderboard,
   formatFrames,
   parseLeaderboardWindow,
@@ -104,7 +105,7 @@ function Breadcrumb({ game, challengeName }: { game: string; challengeName: stri
     <nav className="text-sm text-slate-500">
       <Link href="/" className="hover:text-slate-300">Leaderboards</Link>
       <span className="mx-2">/</span>
-      <span className="text-slate-400">{game}</span>
+      <Link href={gameHref(game)} className="text-slate-400 hover:text-slate-200">{game}</Link>
       <span className="mx-2">/</span>
       <span className="text-slate-300">{challengeName}</span>
     </nav>

--- a/src/app/g/[game]/page.tsx
+++ b/src/app/g/[game]/page.tsx
@@ -1,0 +1,108 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import {
+  challengeHref,
+  formatFrames,
+  listChallengeSummaries,
+  type ChallengeSummary,
+} from '@/lib/leaderboard';
+
+// Skip build-time pre-render — we don't have a DB at build time on Railway.
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: Promise<{ game: string }>;
+}
+
+export default async function GameDetailPage({ params }: PageProps) {
+  const { game: gameParam } = await params;
+  const game = decodeURIComponent(gameParam);
+
+  const summaries = await listChallengeSummaries(game);
+  if (summaries.length === 0) notFound();
+
+  const totalRuns = summaries.reduce((sum, s) => sum + s.runCount, 0);
+
+  return (
+    <div>
+      <Breadcrumb game={game} />
+
+      <h1 className="font-display text-2xl font-bold text-white mt-2">{game}</h1>
+      <p className="text-sm text-slate-400 mb-6">
+        {summaries.length} challenge{summaries.length === 1 ? '' : 's'} · {totalRuns} run{totalRuns === 1 ? '' : 's'}
+      </p>
+
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {summaries.map((c) => (
+          <li key={`${c.game}::${c.challengeName}`}>
+            <ChallengeCard summary={c} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Breadcrumb({ game }: { game: string }) {
+  return (
+    <nav className="text-sm text-slate-500">
+      <Link href="\" className="hover:text-slate-300">Leaderboards</Link>
+      <span className="mx-2">/</span>
+      <span className="text-slate-300">{game}</span>
+    </nav>
+  );
+}
+
+function ChallengeCard({ summary }: { summary: ChallengeSummary }) {
+  const top = summary.topRun;
+  return (
+    <Link
+      href={challengeHref(summary.game, summary.challengeName)}
+      className="group block rounded-lg border border-slate-700 bg-slate-900 p-4 transition-colors hover:border-indigo-500 hover:bg-slate-800"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="font-medium text-slate-100 truncate">{summary.challengeName}</div>
+          <div className="text-xs text-slate-500 mt-0.5">
+            {summary.runCount} run{summary.runCount === 1 ? '' : 's'}
+          </div>
+        </div>
+        <span
+          className="shrink-0 rounded-full bg-indigo-500/20 px-2 py-0.5 text-xs font-medium text-indigo-300"
+          aria-hidden="true"
+        >
+          View &rarr;
+        </span>
+      </div>
+
+      {top && (
+        <div className="mt-3 flex items-center gap-2 rounded-md bg-slate-925 px-2.5 py-2 text-sm">
+          <span className="font-mono text-amber-300" aria-label="Rank 1">#1</span>
+          {top.userPictureUrl ? (
+            <Image
+              src={top.userPictureUrl}
+              alt=""
+              width={20}
+              height={20}
+              className="rounded-full"
+            />
+          ) : (
+            <div className="w-5 h-5 rounded-full bg-slate-700" aria-hidden="true" />
+          )}
+          <span className="text-slate-200 truncate flex-1">{top.userName}</span>
+          <span className="font-mono text-slate-300 tabular-nums">
+            {formatTopMetric(top.score, top.completionTimeFrames)}
+          </span>
+        </div>
+      )}
+    </Link>
+  );
+}
+
+function formatTopMetric(score: number | null, frames: number | null): string {
+  if (score != null && frames != null) return `${score.toLocaleString()} · ${formatFrames(frames)}`;
+  if (score != null)                   return score.toLocaleString();
+  if (frames != null)                  return formatFrames(frames);
+  return '—';
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,11 +4,12 @@ import {
   challengeHref,
   formatFrames,
   formatRelative,
+  gameHref,
   getOverallStats,
   getRecentRuns,
-  listChallengeSummaries,
+  listGames,
   userProfileHref,
-  type ChallengeSummary,
+  type GameSummary,
   type RecentRunEntry,
 } from '@/lib/leaderboard';
 
@@ -16,17 +17,17 @@ import {
 export const dynamic = 'force-dynamic';
 
 export default async function HomePage() {
-  const [stats, summaries, recent] = await Promise.all([
+  const [stats, games, recent] = await Promise.all([
     getOverallStats(),
-    listChallengeSummaries(),
-    getRecentRuns(10),
+    listGames(),
+    getRecentRuns(8),
   ]);
 
   return (
     <div className="space-y-10">
       <Hero stats={stats} />
 
-      {summaries.length === 0 ? (
+      {games.length === 0 ? (
         <section className="rounded-lg border border-dashed border-slate-700 p-8 text-center">
           <p className="text-slate-400">
             No runs submitted yet. Be the first — open the FlawlessNes app and beat a challenge.
@@ -34,7 +35,7 @@ export default async function HomePage() {
         </section>
       ) : (
         <>
-          <ChallengesSection summaries={summaries} />
+          <GamesSection games={games} />
           {recent.length > 0 && <RecentActivity runs={recent} />}
         </>
       )}
@@ -74,80 +75,53 @@ function Stat({ label, value }: { label: string; value: number }) {
   );
 }
 
-function ChallengesSection({ summaries }: { summaries: ChallengeSummary[] }) {
-  // Group by game while preserving the alphabetical order from the DB.
-  const byGame = new Map<string, ChallengeSummary[]>();
-  for (const s of summaries) {
-    const list = byGame.get(s.game);
-    if (list) list.push(s);
-    else byGame.set(s.game, [s]);
-  }
-
+function GamesSection({ games }: { games: GameSummary[] }) {
   return (
-    <section className="space-y-8">
-      {Array.from(byGame.entries()).map(([game, list]) => (
-        <div key={game}>
-          <h2 className="font-display text-xl font-semibold text-white mb-3">{game}</h2>
-          <ul className="grid gap-3 sm:grid-cols-2">
-            {list.map((c) => (
-              <li key={`${c.game}::${c.challengeName}`}>
-                <ChallengeCard summary={c} />
-              </li>
-            ))}
-          </ul>
-        </div>
-      ))}
+    <section>
+      <h2 className="font-display text-xl font-semibold text-white mb-3">Games</h2>
+      <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {games.map((g) => (
+          <li key={g.game}>
+            <GameTile game={g} />
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }
 
-function ChallengeCard({ summary }: { summary: ChallengeSummary }) {
-  const top = summary.topRun;
+function GameTile({ game }: { game: GameSummary }) {
   return (
     <Link
-      href={challengeHref(summary.game, summary.challengeName)}
-      className="group block rounded-lg border border-slate-700 bg-slate-900 p-4 transition-colors hover:border-indigo-500 hover:bg-slate-800"
+      href={gameHref(game.game)}
+      className="group block rounded-lg border border-slate-700 bg-slate-900 p-5 transition-colors hover:border-indigo-500 hover:bg-slate-800"
     >
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="font-medium text-slate-100 truncate">{summary.challengeName}</div>
-          <div className="text-xs text-slate-500 mt-0.5">
-            {summary.runCount} run{summary.runCount === 1 ? '' : 's'}
-          </div>
-        </div>
+        <h3 className="font-display text-lg font-semibold text-white truncate">{game.game}</h3>
         <span
           className="shrink-0 rounded-full bg-indigo-500/20 px-2 py-0.5 text-xs font-medium text-indigo-300"
           aria-hidden="true"
         >
-          View &rarr;
+          Browse &rarr;
         </span>
       </div>
-
-      {top && (
-        <div className="mt-3 flex items-center gap-2 rounded-md bg-slate-925 px-2.5 py-2 text-sm">
-          <span className="font-mono text-amber-300" aria-label="Rank 1">#1</span>
-          {top.userPictureUrl ? (
-            <Image
-              src={top.userPictureUrl}
-              alt=""
-              width={20}
-              height={20}
-              className="rounded-full"
-            />
-          ) : (
-            <div className="w-5 h-5 rounded-full bg-slate-700" aria-hidden="true" />
-          )}
-          {/* Username inside the card-Link can't be its own Link in valid
-              HTML, so we keep it as plain text here. The whole card already
-              navigates to the challenge; the dedicated profile path is via
-              the username column on the per-challenge leaderboard table. */}
-          <span className="text-slate-200 truncate flex-1">{top.userName}</span>
-          <span className="font-mono text-slate-300 tabular-nums">
-            {formatTopMetric(top.score, top.completionTimeFrames)}
-          </span>
-        </div>
-      )}
+      <dl className="mt-3 grid grid-cols-3 gap-2 text-center">
+        <TileStat label="challenges" value={game.totalChallenges} />
+        <TileStat label="runs"       value={game.totalRuns} />
+        <TileStat label="players"    value={game.totalPlayers} />
+      </dl>
     </Link>
+  );
+}
+
+function TileStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md bg-slate-925 px-2 py-1.5">
+      <dd className="font-mono text-base font-semibold text-slate-100 tabular-nums">
+        {value.toLocaleString()}
+      </dd>
+      <dt className="text-[10px] uppercase tracking-wider text-slate-500">{label}</dt>
+    </div>
   );
 }
 
@@ -195,7 +169,9 @@ function RecentActivity({ runs }: { runs: RecentRunEntry[] }) {
                   {r.challengeName}
                 </Link>
                 <span className="text-slate-500"> in </span>
-                <span className="text-slate-100">{r.game}</span>
+                <Link href={gameHref(r.game)} className="text-slate-100 hover:text-indigo-300">
+                  {r.game}
+                </Link>
               </div>
               <div className="text-xs text-slate-500 mt-0.5">
                 {formatTopMetric(r.score, r.completionTimeFrames)}

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -176,10 +176,17 @@ export interface ChallengeSummary {
   topRun: LeaderboardEntry | null;
 }
 
-export async function listChallengeSummaries(): Promise<ChallengeSummary[]> {
+// `game` (optional) scopes the result to a single game's challenges, used
+// by /g/[game] to render the game-detail page. Unscoped, this powers the
+// home page's cross-game catalog.
+export async function listChallengeSummaries(game?: string): Promise<ChallengeSummary[]> {
   const groups = await prisma.run.groupBy({
     by: ['game', 'challengeName'],
-    where: { hiddenAt: null, user: { bannedAt: null } },
+    where: {
+      hiddenAt: null,
+      user: { bannedAt: null },
+      ...(game ? { game } : {}),
+    },
     _count: { _all: true },
     orderBy: [{ game: 'asc' }, { challengeName: 'asc' }],
   });
@@ -194,6 +201,51 @@ export async function listChallengeSummaries(): Promise<ChallengeSummary[]> {
         challengeName: g.challengeName,
         runCount: g._count._all,
         topRun: top[0] ?? null,
+      };
+    }),
+  );
+}
+
+// One row per game that has at least one visible run. Powers the game-tile
+// grid on the home page — each tile links to /g/[game] and shows the per-
+// game stat strip (challenges / runs / players).
+//
+// Implementation: one groupBy('game') for the run counts, then per-game
+// secondary groupBy queries to count distinct challenges and distinct
+// players. N+1 with N = number of games (single-digit at our scale, low
+// double-digit in the foreseeable future) — revisit with a single SQL
+// window-function query if the catalog ever grows beyond ~50 games.
+export interface GameSummary {
+  game: string;
+  totalChallenges: number;
+  totalRuns: number;
+  totalPlayers: number;
+}
+
+export async function listGames(): Promise<GameSummary[]> {
+  const games = await prisma.run.groupBy({
+    by: ['game'],
+    where: { hiddenAt: null, user: { bannedAt: null } },
+    _count: { _all: true },
+    orderBy: { game: 'asc' },
+  });
+  return Promise.all(
+    games.map(async (g) => {
+      const [challengeRows, playerRows] = await Promise.all([
+        prisma.run.groupBy({
+          by: ['challengeName'],
+          where: { game: g.game, hiddenAt: null, user: { bannedAt: null } },
+        }),
+        prisma.run.groupBy({
+          by: ['userId'],
+          where: { game: g.game, hiddenAt: null, user: { bannedAt: null } },
+        }),
+      ]);
+      return {
+        game: g.game,
+        totalChallenges: challengeRows.length,
+        totalRuns: g._count._all,
+        totalPlayers: playerRows.length,
       };
     }),
   );
@@ -424,4 +476,8 @@ export function formatFrames(frames: number | null): string {
 // site never disagree.
 export function challengeHref(game: string, challengeName: string): string {
   return `/c/${encodeURIComponent(game)}/${encodeURIComponent(challengeName)}`;
+}
+
+export function gameHref(game: string): string {
+  return `/g/${encodeURIComponent(game)}`;
 }

--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -1,6 +1,7 @@
 import {
   formatFrames,
   challengeHref,
+  gameHref,
   parseLeaderboardWindow,
   parseLeaderboardView,
   windowSince,
@@ -42,6 +43,16 @@ describe('challengeHref', () => {
     const name = 'Level 1/2 warp';
     const href = challengeHref('Super Mario Bros', name);
     expect(href.includes('%2F')).toBe(true);
+  });
+});
+
+describe('gameHref', () => {
+  test('builds /g/<game>', () => {
+    expect(gameHref('Castlevania')).toBe('/g/Castlevania');
+  });
+
+  test('percent-encodes spaces', () => {
+    expect(gameHref('Super Mario Bros')).toBe('/g/Super%20Mario%20Bros');
   });
 });
 


### PR DESCRIPTION
## Summary
First step toward making the leaderboard browseable as the catalog grows. Per the design discussion, the flat per-challenge list scales awkwardly past ~30 challenges — this restores a "pick a game first" reading order at the cost of one extra click per challenge.

**Routes:**
- \`/\` — replaces the per-challenge cards with a grid of **game tiles** (challenges / runs / players stat strip per game). Recent-activity feed stays but trims to 8 entries and moves below the tiles.
- \`/g/[game]\` — new. Shows the game's challenges as the cards previously seen on home. Phase 2 will add category groupings here.

**New library helpers (\`src/lib/leaderboard.ts\`):**
- \`listGames()\` — one \`GameSummary\` row per distinct game with \`totalChallenges\` / \`totalRuns\` / \`totalPlayers\`.
- \`gameHref(game)\` — \`/g/<encoded-game>\` URL builder, matches \`challengeHref\`.
- \`listChallengeSummaries(game?)\` gains an optional game filter for the new route.

**Linkability touch-ups:**
- Game name in each Recent-activity row now links to its hub.
- Breadcrumb on \`/c/[game]/[challenge]\` turns the middle segment into a link to \`/g/[game]\`.

**Out of scope (Phase 2):**
- Category grouping inside \`/g/[game]\` — needs a \`category\` field on each challenge in the assets repo.
- Game cover artwork — game tiles are name + stats only for now.
- Header search — Phase 3.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 38/38 passing (added 2 \`gameHref\` cases)
- [ ] \`npm run dev\` — home shows game tiles, click → game page lists challenges, breadcrumb middle is clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)