### PR TITLE
feat(nav): phase 2 — category groupings on /g/[game]

### DIFF
--- a/src/app/g/[game]/page.tsx
+++ b/src/app/g/[game]/page.tsx
@@ -7,6 +7,12 @@ import {
   listChallengeSummaries,
   type ChallengeSummary,
 } from '@/lib/leaderboard';
+import {
+  CATEGORY_ORDER,
+  categoryLabel,
+  getChallengesManifest,
+  manifestKey,
+} from '@/lib/challenges-manifest';
 
 // Skip build-time pre-render — we don't have a DB at build time on Railway.
 export const dynamic = 'force-dynamic';
@@ -15,13 +21,28 @@ interface PageProps {
   params: Promise<{ game: string }>;
 }
 
+// Local rendering type — ChallengeSummary plus the category we looked up
+// from the assets-repo manifest. Category may be undefined (manifest fetch
+// failed, or the assets repo hasn't shipped a category for this entry yet),
+// in which case the row falls into the "Other" group.
+type AnnotatedSummary = ChallengeSummary & { category?: string };
+
 export default async function GameDetailPage({ params }: PageProps) {
   const { game: gameParam } = await params;
   const game = decodeURIComponent(gameParam);
 
-  const summaries = await listChallengeSummaries(game);
+  const [summaries, manifest] = await Promise.all([
+    listChallengeSummaries(game),
+    getChallengesManifest(),
+  ]);
   if (summaries.length === 0) notFound();
 
+  const annotated: AnnotatedSummary[] = summaries.map((s) => ({
+    ...s,
+    category: manifest.get(manifestKey(s.game, s.challengeName))?.category,
+  }));
+
+  const groups = groupByCategory(annotated);
   const totalRuns = summaries.reduce((sum, s) => sum + s.runCount, 0);
 
   return (
@@ -33,14 +54,64 @@ export default async function GameDetailPage({ params }: PageProps) {
         {summaries.length} challenge{summaries.length === 1 ? '' : 's'} · {totalRuns} run{totalRuns === 1 ? '' : 's'}
       </p>
 
+      <div className="space-y-8">
+        {groups.map(({ category, items }) => (
+          <CategorySection key={category} category={category} items={items} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Bucket annotated summaries by category and emit groups in a stable order
+// (CATEGORY_ORDER, then anything unknown, then 'other' last). Groups with
+// zero items are dropped so we don't render empty headers.
+function groupByCategory(
+  rows: AnnotatedSummary[],
+): { category: string; items: AnnotatedSummary[] }[] {
+  const buckets = new Map<string, AnnotatedSummary[]>();
+  for (const r of rows) {
+    const key = r.category ?? 'other';
+    const list = buckets.get(key);
+    if (list) list.push(r);
+    else buckets.set(key, [r]);
+  }
+  const ordered: string[] = [];
+  for (const k of CATEGORY_ORDER) if (buckets.has(k)) ordered.push(k);
+  // Any unknown categories from upstream (e.g. assets repo adds 'gauntlet'
+  // before we update the leaderboard's CATEGORY_ORDER) get rendered between
+  // known categories and the 'other' bucket, sorted alphabetically.
+  const unknowns = Array.from(buckets.keys())
+    .filter((k) => k !== 'other' && !CATEGORY_ORDER.includes(k))
+    .sort();
+  ordered.push(...unknowns);
+  if (buckets.has('other')) ordered.push('other');
+  return ordered.map((category) => ({ category, items: buckets.get(category)! }));
+}
+
+function CategorySection({
+  category,
+  items,
+}: {
+  category: string;
+  items: AnnotatedSummary[];
+}) {
+  return (
+    <section>
+      <h2 className="font-display text-lg font-semibold text-white mb-3 flex items-baseline gap-2">
+        {categoryLabel(category)}
+        <span className="text-xs font-normal text-slate-500">
+          {items.length} challenge{items.length === 1 ? '' : 's'}
+        </span>
+      </h2>
       <ul className="grid gap-3 sm:grid-cols-2">
-        {summaries.map((c) => (
+        {items.map((c) => (
           <li key={`${c.game}::${c.challengeName}`}>
             <ChallengeCard summary={c} />
           </li>
         ))}
       </ul>
-    </div>
+    </section>
   );
 }
 

--- a/src/lib/challenges-manifest.ts
+++ b/src/lib/challenges-manifest.ts
@@ -1,0 +1,107 @@
+// Reads the challenges.json manifest from the assets repo so the
+// leaderboard can render game/challenge metadata (category, difficulty)
+// that the Run table doesn't carry. Assets are the source of truth — we
+// don't replicate the manifest into the DB at submission time so authors
+// can re-categorize without a migration.
+//
+// Network call is cheap (~3 KB) and infrequent. We cache in memory at
+// module scope with a TTL, plus serve stale on failure so a flaky
+// GitHub raw response doesn't break the page.
+
+const MANIFEST_URL =
+  'https://raw.githubusercontent.com/heliacode/retrochallenges-assets/refs/heads/main/challenges.json';
+const TTL_MS = 5 * 60 * 1000; // 5 minutes — matches Next.js fetch revalidate hint below
+
+interface RawManifestChallenge {
+  name: string;
+  category?: string;
+  difficulty?: string;
+}
+interface RawManifestGame {
+  name: string;
+  challenges: RawManifestChallenge[];
+}
+interface RawManifest {
+  games: RawManifestGame[];
+}
+
+export interface ChallengeMeta {
+  game: string;
+  challengeName: string;
+  category?: string;
+  difficulty?: string;
+}
+
+// Map key: `${game}::${challengeName}`. Identical key shape used elsewhere
+// in the app for (game, challenge) tuples — see UserProfile aggregation.
+export function manifestKey(game: string, challengeName: string): string {
+  return `${game}::${challengeName}`;
+}
+
+let cache: { meta: Map<string, ChallengeMeta>; expiresAt: number } | null = null;
+
+export async function getChallengesManifest(): Promise<Map<string, ChallengeMeta>> {
+  const now = Date.now();
+  if (cache && now < cache.expiresAt) return cache.meta;
+
+  try {
+    const res = await fetch(MANIFEST_URL, {
+      // Hint Next.js's fetch cache to revalidate every 5 min on the server.
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) throw new Error(`manifest fetch ${res.status}`);
+    const data = (await res.json()) as RawManifest;
+    const meta = parseManifest(data);
+    cache = { meta, expiresAt: now + TTL_MS };
+    return meta;
+  } catch (err) {
+    console.warn(
+      '[manifest] fetch failed, serving',
+      cache ? 'stale cache' : 'empty map',
+      ':',
+      (err as Error).message,
+    );
+    // Serve stale rather than empty if we ever had a successful fetch —
+    // an outage shouldn't make the navigation regress to flat lists.
+    return cache?.meta ?? new Map();
+  }
+}
+
+// Pure transform — exported so tests can hit it without touching fetch.
+export function parseManifest(data: RawManifest): Map<string, ChallengeMeta> {
+  const out = new Map<string, ChallengeMeta>();
+  if (!data || !Array.isArray(data.games)) return out;
+  for (const g of data.games) {
+    if (!g || typeof g.name !== 'string' || !Array.isArray(g.challenges)) continue;
+    for (const c of g.challenges) {
+      if (!c || typeof c.name !== 'string') continue;
+      out.set(manifestKey(g.name, c.name), {
+        game: g.name,
+        challengeName: c.name,
+        category: c.category,
+        difficulty: c.difficulty,
+      });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Category vocabulary (also lives in challenges.json metadata.categories;
+// duplicated here so the leaderboard renders consistently even if the
+// manifest fetch fails or a new category appears upstream).
+// ---------------------------------------------------------------------------
+export const CATEGORY_ORDER: readonly string[] = ['boss', 'speedrun', 'survival', 'score'];
+
+export const CATEGORY_LABELS: Record<string, string> = {
+  boss:     'Boss Fights',
+  speedrun: 'Speedruns',
+  survival: 'Survival',
+  score:    'Score Targets',
+  other:    'Other',
+};
+
+export function categoryLabel(category: string | undefined): string {
+  if (!category) return CATEGORY_LABELS.other;
+  return CATEGORY_LABELS[category] ?? category;
+}

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -1,0 +1,87 @@
+import {
+  parseManifest,
+  manifestKey,
+  categoryLabel,
+} from '../src/lib/challenges-manifest';
+
+describe('parseManifest', () => {
+  test('empty / null / malformed input returns empty map', () => {
+    expect(parseManifest(undefined as unknown as { games: never[] }).size).toBe(0);
+    expect(parseManifest(null as unknown as { games: never[] }).size).toBe(0);
+    expect(parseManifest({} as unknown as { games: never[] }).size).toBe(0);
+    expect(parseManifest({ games: 'not an array' } as unknown as { games: never[] }).size).toBe(0);
+  });
+
+  test('skips games / challenges with missing or wrong-typed names', () => {
+    const m = parseManifest({
+      games: [
+        { name: 'OK', challenges: [{ name: 'Real', category: 'boss' }] },
+        { name: 'Bad', challenges: [{ category: 'score' } as unknown as { name: string }] }, // missing name
+        { challenges: [{ name: 'NoGameName' }] } as unknown as { name: string; challenges: never[] },
+        null as unknown as { name: string; challenges: never[] },
+      ],
+    });
+    expect(m.size).toBe(1);
+    expect(m.get('OK::Real')?.category).toBe('boss');
+  });
+
+  test('round-trips category and difficulty', () => {
+    const m = parseManifest({
+      games: [
+        {
+          name: 'Castlevania',
+          challenges: [
+            { name: 'Phantom Bat', category: 'boss', difficulty: 'Medium' },
+            { name: 'Get 5000 points!', category: 'score', difficulty: 'Easy' },
+          ],
+        },
+      ],
+    });
+    expect(m.size).toBe(2);
+    expect(m.get(manifestKey('Castlevania', 'Phantom Bat'))).toEqual({
+      game: 'Castlevania',
+      challengeName: 'Phantom Bat',
+      category: 'boss',
+      difficulty: 'Medium',
+    });
+    expect(m.get(manifestKey('Castlevania', 'Get 5000 points!'))?.category).toBe('score');
+  });
+
+  test('absent category / difficulty stays undefined (not coerced to empty string)', () => {
+    const m = parseManifest({
+      games: [{ name: 'X', challenges: [{ name: 'Y' }] }],
+    });
+    const meta = m.get(manifestKey('X', 'Y'));
+    expect(meta).toBeDefined();
+    expect(meta?.category).toBeUndefined();
+    expect(meta?.difficulty).toBeUndefined();
+  });
+});
+
+describe('manifestKey', () => {
+  test('joins game and challenge name with ::', () => {
+    expect(manifestKey('Mega Man 2', 'Metal Man Boss Fight')).toBe(
+      'Mega Man 2::Metal Man Boss Fight',
+    );
+  });
+});
+
+describe('categoryLabel', () => {
+  test('maps known categories to display strings', () => {
+    expect(categoryLabel('boss')).toBe('Boss Fights');
+    expect(categoryLabel('speedrun')).toBe('Speedruns');
+    expect(categoryLabel('survival')).toBe('Survival');
+    expect(categoryLabel('score')).toBe('Score Targets');
+  });
+
+  test('undefined falls through to "Other"', () => {
+    expect(categoryLabel(undefined)).toBe('Other');
+  });
+
+  test('unknown category strings pass through verbatim', () => {
+    // Forward-compat: assets repo can ship a new category before we update
+    // the leaderboard's vocabulary, and we render it as-is rather than
+    // hiding it.
+    expect(categoryLabel('gauntlet')).toBe('gauntlet');
+  });
+});


### PR DESCRIPTION
## Summary
Phase 2 of the navigation revamp. Builds on the assets-repo \`category\` field (heliacode/retrochallenges-assets#59).

\`/g/[game]\` now fetches challenges.json from the assets repo at runtime, looks up each summary's category, and groups them under display headers:
- **Boss Fights** (7 — most of MM2 + 3 Castlevania bosses)
- **Speedruns** (1 — Cross the Big Bridge)
- **Survival** (3 — Fish-People escape + 2 QuickMan stages)
- **Score Targets** (3 — Get 5000, Fleaman 10000, DK 2000)

**Manifest fetcher (\`src/lib/challenges-manifest.ts\`):**
- 5-min in-memory TTL cache.
- Stale-on-failure: if GitHub raw flakes after a successful first fetch, we keep serving the cached map instead of regressing to a flat list.
- \`parseManifest()\` is exported (pure) for test coverage without touching \`fetch\`.
- \`CATEGORY_ORDER\` and \`CATEGORY_LABELS\` are duplicated locally so the leaderboard renders consistently even if the manifest is unavailable on first request.

**Forward compat:** if the assets repo ships a new category (e.g. \`gauntlet\`) before the leaderboard updates its vocabulary, that category renders alphabetically between the known ones and the \`other\` bucket.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 46/46 (8 new manifest tests covering empty/malformed/round-trip/unknown-category)
- [ ] \`npm run dev\` — visit \`/g/Castlevania\`, verify "Boss Fights / Speedruns / Survival / Score Targets" headers each have the right challenge count

🤖 Generated with [Claude Code](https://claude.com/claude-code)