### PR TITLE
feat(nav): phase 3 — header search jump

### DIFF
--- a/src/app/api/search-index/route.ts
+++ b/src/app/api/search-index/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { challengeHref, gameHref } from '@/lib/leaderboard';
+import { getChallengesManifest, type SearchItem } from '@/lib/challenges-manifest';
+
+// Flat search index for the header HeaderSearch. Built from the assets-repo
+// manifest so brand-new challenges (zero runs yet) are still navigable.
+// Public, GET-only, no auth — same trust model as challenges.json itself.
+//
+// Cached upstream by the manifest fetcher (5-min TTL); we add Cache-Control
+// here so a CDN / browser can serve the same shape directly without round-
+// tripping the server.
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const manifest = await getChallengesManifest();
+  const games = new Set<string>();
+  const challengeItems: SearchItem[] = [];
+  for (const m of manifest.values()) {
+    games.add(m.game);
+    challengeItems.push({
+      type: 'challenge',
+      label: m.challengeName,
+      context: m.game,
+      href: challengeHref(m.game, m.challengeName),
+    });
+  }
+  const gameItems: SearchItem[] = Array.from(games)
+    .sort((a, b) => a.localeCompare(b))
+    .map((g) => ({ type: 'game', label: g, href: gameHref(g) }));
+
+  // Games first so a query like "castl" surfaces the hub before its
+  // individual challenges; alphabetical within each tier.
+  challengeItems.sort((a, b) => a.label.localeCompare(b.label));
+  const items: SearchItem[] = [...gameItems, ...challengeItems];
+
+  return NextResponse.json(items, {
+    headers: {
+      'Cache-Control': 'public, max-age=60, s-maxage=300, stale-while-revalidate=300',
+    },
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { HeaderSearch } from '@/components/HeaderSearch';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -20,13 +21,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className="h-full bg-slate-925 text-slate-200 font-sans antialiased">
         <header className="border-b border-slate-700 bg-slate-900/80 backdrop-blur sticky top-0 z-10">
-          <div className="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
-            <Link href="/" className="font-display text-xl font-bold text-white">
+          <div className="max-w-5xl mx-auto px-4 py-4 flex items-center gap-4">
+            <Link href="/" className="font-display text-xl font-bold text-white shrink-0">
               FlawlessNes
             </Link>
-            <nav className="text-sm text-slate-400">
-              <span>Leaderboards</span>
-            </nav>
+            <div className="flex-1 flex justify-end">
+              <HeaderSearch />
+            </div>
           </div>
         </header>
 

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { filterSearchItems, type SearchItem } from '@/lib/challenges-manifest';
+
+// Lightweight global jump for the catalog: type a few letters to reach a
+// game or challenge directly without browsing the tile/category hierarchy.
+//
+// Index is fetched lazily on first focus so most page views never pay for
+// it. Filtering is pure substring (case-insensitive) — the index is small
+// (~20 entries today, expected to stay under low triple-digit) so we don't
+// need a fuzzy-match dependency.
+export function HeaderSearch() {
+  const router = useRouter();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [items, setItems] = useState<SearchItem[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+
+  const results = items ? filterSearchItems(items, query) : [];
+
+  // Reset highlight whenever the result set changes (typing, focus, etc.).
+  useEffect(() => {
+    setActiveIdx(0);
+  }, [query, items]);
+
+  // Click outside the search box closes the dropdown. Listening on
+  // mousedown rather than click so a click on a result still fires its
+  // own onClick before we tear down.
+  useEffect(() => {
+    if (!open) return;
+    function onDocMouseDown(e: MouseEvent) {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', onDocMouseDown);
+    return () => document.removeEventListener('mousedown', onDocMouseDown);
+  }, [open]);
+
+  async function ensureIndex() {
+    if (items || loading) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/search-index');
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const data = (await res.json()) as SearchItem[];
+      setItems(data);
+    } catch (err) {
+      console.warn('[search] index fetch failed:', (err as Error).message);
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function navigate(item: SearchItem) {
+    router.push(item.href);
+    setOpen(false);
+    setQuery('');
+    inputRef.current?.blur();
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Escape') {
+      setOpen(false);
+      setQuery('');
+      inputRef.current?.blur();
+      return;
+    }
+    if (!open || results.length === 0) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIdx((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      navigate(results[activeIdx]);
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative w-full sm:w-72">
+      <input
+        ref={inputRef}
+        type="search"
+        placeholder="Search games and challenges…"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => {
+          setOpen(true);
+          ensureIndex();
+        }}
+        onKeyDown={onKeyDown}
+        aria-label="Search games and challenges"
+        aria-autocomplete="list"
+        aria-expanded={open && results.length > 0}
+        className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-1.5 text-sm text-slate-200 placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none"
+      />
+      {open && query.trim() !== '' && (
+        <div className="absolute right-0 left-0 mt-1 z-20 overflow-hidden rounded-md border border-slate-700 bg-slate-900 shadow-lg">
+          {results.length === 0 ? (
+            <div className="px-3 py-2 text-sm text-slate-500">
+              {items === null ? 'Loading…' : `No matches for “${query.trim()}”`}
+            </div>
+          ) : (
+            <ul role="listbox" className="max-h-72 overflow-y-auto">
+              {results.map((r, idx) => (
+                <li
+                  key={`${r.type}:${r.href}`}
+                  role="option"
+                  aria-selected={idx === activeIdx}
+                  onMouseEnter={() => setActiveIdx(idx)}
+                  onMouseDown={(e) => {
+                    // mousedown so we beat the document mousedown that
+                    // would otherwise close the dropdown before click.
+                    e.preventDefault();
+                    navigate(r);
+                  }}
+                  className={`flex items-center gap-2 px-3 py-2 text-sm cursor-pointer ${
+                    idx === activeIdx
+                      ? 'bg-indigo-500/20 text-white'
+                      : 'text-slate-200 hover:bg-slate-800'
+                  }`}
+                >
+                  <span
+                    className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${
+                      r.type === 'game'
+                        ? 'bg-indigo-500/20 text-indigo-300'
+                        : 'bg-slate-700 text-slate-300'
+                    }`}
+                  >
+                    {r.type}
+                  </span>
+                  <span className="truncate flex-1">{r.label}</span>
+                  {r.context && (
+                    <span className="text-xs text-slate-500 truncate shrink-0">{r.context}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/challenges-manifest.ts
+++ b/src/lib/challenges-manifest.ts
@@ -105,3 +105,45 @@ export function categoryLabel(category: string | undefined): string {
   if (!category) return CATEGORY_LABELS.other;
   return CATEGORY_LABELS[category] ?? category;
 }
+
+// ---------------------------------------------------------------------------
+// Search index — flat list of games + challenges that the header search
+// component fuzzy-matches against. Built from the manifest so it includes
+// challenges that have zero runs yet (otherwise users couldn't navigate
+// to a brand-new challenge until someone played it).
+// ---------------------------------------------------------------------------
+export type SearchItemType = 'game' | 'challenge';
+export interface SearchItem {
+  type: SearchItemType;
+  label: string;       // headline text shown in the dropdown row
+  context?: string;    // secondary line — e.g. parent game for a challenge
+  href: string;        // navigation target on click / Enter
+}
+
+// Substring filter used by the header search dropdown. Case-insensitive,
+// matches the query against either the label or the context. Returns up to
+// `limit` items, ordered: exact-prefix label matches first, then prefix
+// context matches, then any-substring matches. Stable within each tier.
+export function filterSearchItems(
+  items: readonly SearchItem[],
+  query: string,
+  limit = 8,
+): SearchItem[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  type Scored = { item: SearchItem; tier: number; idx: number };
+  const scored: Scored[] = [];
+  for (let idx = 0; idx < items.length; idx++) {
+    const it = items[idx];
+    const label = it.label.toLowerCase();
+    const ctx   = (it.context ?? '').toLowerCase();
+    let tier = -1;
+    if (label.startsWith(q))           tier = 0;
+    else if (ctx && ctx.startsWith(q)) tier = 1;
+    else if (label.includes(q))        tier = 2;
+    else if (ctx && ctx.includes(q))   tier = 3;
+    if (tier >= 0) scored.push({ item: it, tier, idx });
+  }
+  scored.sort((a, b) => (a.tier !== b.tier ? a.tier - b.tier : a.idx - b.idx));
+  return scored.slice(0, limit).map((s) => s.item);
+}

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -2,6 +2,8 @@ import {
   parseManifest,
   manifestKey,
   categoryLabel,
+  filterSearchItems,
+  type SearchItem,
 } from '../src/lib/challenges-manifest';
 
 describe('parseManifest', () => {
@@ -83,5 +85,50 @@ describe('categoryLabel', () => {
     // the leaderboard's vocabulary, and we render it as-is rather than
     // hiding it.
     expect(categoryLabel('gauntlet')).toBe('gauntlet');
+  });
+});
+
+describe('filterSearchItems', () => {
+  const items: SearchItem[] = [
+    { type: 'game',      label: 'Castlevania',           href: '/g/Castlevania' },
+    { type: 'game',      label: 'Mega Man 2',            href: '/g/Mega%20Man%202' },
+    { type: 'challenge', label: 'Phantom Bat — No Subweapon!', context: 'Castlevania', href: '/c/...' },
+    { type: 'challenge', label: 'Metal Man Boss Fight',  context: 'Mega Man 2',  href: '/c/...' },
+    { type: 'challenge', label: 'Cross the Big Bridge!', context: 'Castlevania', href: '/c/...' },
+  ];
+
+  test('empty / whitespace query returns no results', () => {
+    expect(filterSearchItems(items, '')).toEqual([]);
+    expect(filterSearchItems(items, '   ')).toEqual([]);
+  });
+
+  test('case-insensitive substring match on label', () => {
+    const r = filterSearchItems(items, 'METAL');
+    expect(r.length).toBe(1);
+    expect(r[0].label).toBe('Metal Man Boss Fight');
+  });
+
+  test('matches against context (parent game)', () => {
+    const r = filterSearchItems(items, 'castlevania');
+    // Game tile + 2 challenges sharing the Castlevania context.
+    expect(r.length).toBe(3);
+    // Game (label match, tier 0) ranks before challenges (context match, tier 1+).
+    expect(r[0].type).toBe('game');
+  });
+
+  test('prefix matches outrank infix matches', () => {
+    const r = filterSearchItems(items, 'man');
+    // "Mega Man 2" (label prefix) and "Metal Man Boss Fight" both match;
+    // game with prefix-on-label should appear before challenge that only
+    // contains "man" mid-string.
+    expect(r[0].label).toBe('Mega Man 2');
+  });
+
+  test('respects the limit', () => {
+    expect(filterSearchItems(items, 'a', 2).length).toBe(2);
+  });
+
+  test('no matches returns empty array', () => {
+    expect(filterSearchItems(items, 'xyzzy')).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
Closes the navigation revamp. The layout header gets a slim search input that replaces the static "Leaderboards" nav span; type a few letters to jump directly to a game or challenge without browsing the tile/category hierarchy.

**Pieces:**
- \`/api/search-index\` (Next.js Route Handler) — flat JSON of \`{ type: 'game' | 'challenge', label, context?, href }\` built from the assets-repo manifest. \`Cache-Control: max-age=60, s-maxage=300, swr=300\`.
- \`HeaderSearch\` (client component) — lazy-fetches the index on first focus, dropdown with keyboard nav (↑↓ Enter Esc), click-outside close, mousedown-to-navigate so the row click beats the document's close handler.
- \`filterSearchItems\` (pure helper, in \`challenges-manifest.ts\`) — substring filter with 4-tier ranking (label-prefix > context-prefix > label-substring > context-substring) and a configurable result limit. Pure JS substring is enough at our scale (~20 items today, low triple-digit worst-case).

**Why no fuzzy-match dep:** ~20 items × substring is ~0.01 ms. Adding Fuse.js or similar would buy nothing visible while inflating the client bundle.

**Forward compat:** if the assets repo ships an unknown category for a challenge, the search index still includes it (label / context still match) — so search works even if category grouping doesn't recognize the type yet.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 52/52 (6 new \`filterSearchItems\` cases)
- [ ] \`npm run dev\` — header has search input; type "metal" → "Metal Man Boss Fight" highlighted; Enter navigates; Esc clears
- [ ] Mobile: input collapses gracefully, dropdown anchored to input

🤖 Generated with [Claude Code](https://claude.com/claude-code)