### PR TITLE
chore: capitalize NES → FlawlessNES

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,8 @@ import { HeaderSearch } from '@/components/HeaderSearch';
 import './globals.css';
 
 export const metadata: Metadata = {
-  title: 'FlawlessNes Leaderboard',
-  description: 'Community leaderboards for FlawlessNes — retro gaming challenges with verified completions.',
+  title: 'FlawlessNES Leaderboard',
+  description: 'Community leaderboards for FlawlessNES — retro gaming challenges with verified completions.',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -23,7 +23,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <header className="border-b border-slate-700 bg-slate-900/80 backdrop-blur sticky top-0 z-10">
           <div className="max-w-5xl mx-auto px-4 py-4 flex items-center gap-4">
             <Link href="/" className="font-display text-xl font-bold text-white shrink-0">
-              FlawlessNes
+              FlawlessNES
             </Link>
             <div className="flex-1 flex justify-end">
               <HeaderSearch />
@@ -34,7 +34,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <main className="max-w-5xl mx-auto px-4 py-8">{children}</main>
 
         <footer className="border-t border-slate-700 mt-16 py-6 text-center text-xs text-slate-500">
-          <span>&copy; 2026 FlawlessNes</span>
+          <span>&copy; 2026 FlawlessNES</span>
         </footer>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,7 @@ export default async function HomePage() {
       {games.length === 0 ? (
         <section className="rounded-lg border border-dashed border-slate-700 p-8 text-center">
           <p className="text-slate-400">
-            No runs submitted yet. Be the first — open the FlawlessNes app and beat a challenge.
+            No runs submitted yet. Be the first — open the FlawlessNES app and beat a challenge.
           </p>
         </section>
       ) : (
@@ -52,7 +52,7 @@ function Hero({ stats }: { stats: { totalRuns: number; totalPlayers: number; tot
     <section>
       <h1 className="font-display text-3xl font-bold text-white mb-2">Leaderboards</h1>
       <p className="text-slate-400 mb-5">
-        Community-submitted runs from the FlawlessNes desktop app. Every row is a verified
+        Community-submitted runs from the FlawlessNES desktop app. Every row is a verified
         in-emulator completion — scores land here the moment the challenge pings complete.
       </p>
       <dl className="grid grid-cols-3 gap-3 sm:max-w-md">

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -51,7 +51,7 @@ export async function notifyDiscordTopPlacement(p: DiscordTopPlacementPayload): 
     color,
     url: p.publicHref,
     timestamp: new Date().toISOString(),
-    footer: { text: 'FlawlessNes leaderboard' },
+    footer: { text: 'FlawlessNES leaderboard' },
   };
   if (p.playerAvatarUrl) {
     embed.thumbnail = { url: p.playerAvatarUrl };
@@ -62,7 +62,7 @@ export async function notifyDiscordTopPlacement(p: DiscordTopPlacementPayload): 
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        username: 'FlawlessNes Bot',
+        username: 'FlawlessNES Bot',
         embeds: [embed],
       }),
     });


### PR DESCRIPTION
## Summary
Brand polish ahead of the upcoming website work — the NES acronym should be uppercase.

Touches: page title, header link, hero copy, empty-state callout, footer copyright, Discord webhook bot username + footer text.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 52/52 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)