### PR TITLE
feat(website): show player count on challenge cards

### DIFF
--- a/src/app/leaderboards/g/[game]/page.tsx
+++ b/src/app/leaderboards/g/[game]/page.tsx
@@ -136,6 +136,8 @@ function ChallengeCard({ summary }: { summary: ChallengeSummary }) {
         <div className="min-w-0">
           <div className="font-medium text-slate-100 truncate">{summary.challengeName}</div>
           <div className="text-xs text-slate-500 mt-0.5">
+            {summary.playerCount} player{summary.playerCount === 1 ? '' : 's'}
+            <span className="mx-1.5">&middot;</span>
             {summary.runCount} run{summary.runCount === 1 ? '' : 's'}
           </div>
         </div>

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -173,6 +173,7 @@ export interface ChallengeSummary {
   game: string;
   challengeName: string;
   runCount: number;
+  playerCount: number;
   topRun: LeaderboardEntry | null;
 }
 
@@ -190,16 +191,29 @@ export async function listChallengeSummaries(game?: string): Promise<ChallengeSu
     _count: { _all: true },
     orderBy: [{ game: 'asc' }, { challengeName: 'asc' }],
   });
-  // N+1 with N small (one query per challenge for its rank-1 row). Fine
-  // at our scale (single-digit challenges); revisit with a single window
-  // function query if the catalog grows beyond ~50.
+  // N+1 with N small (two queries per challenge — rank-1 row + distinct-
+  // userId count for the "X players" stat). Fine at our scale (single-
+  // digit challenges); revisit with a single window-function query if the
+  // catalog grows beyond ~50.
   return Promise.all(
     groups.map(async (g) => {
-      const top = await getChallengeLeaderboard(g.game, g.challengeName, 1);
+      const [top, playerGroups] = await Promise.all([
+        getChallengeLeaderboard(g.game, g.challengeName, 1),
+        prisma.run.groupBy({
+          by: ['userId'],
+          where: {
+            game: g.game,
+            challengeName: g.challengeName,
+            hiddenAt: null,
+            user: { bannedAt: null },
+          },
+        }),
+      ]);
       return {
         game: g.game,
         challengeName: g.challengeName,
         runCount: g._count._all,
+        playerCount: playerGroups.length,
         topRun: top[0] ?? null,
       };
     }),


### PR DESCRIPTION
## Summary
The game-detail page (\`/leaderboards/g/[game]\`) only surfaced the rank-1 player on each challenge card. Three users could have submitted runs and the card would still look like a one-player ghost town because only the leader's avatar showed.

Cards now display **\"X players · Y runs\"** in the existing meta line.

## Changes
- \`ChallengeSummary\` gains a \`playerCount\` field
- \`listChallengeSummaries\` fans out a second per-challenge \`groupBy({ by: ['userId'] })\`, parallel-\`Promise.all\`'d with the existing rank-1 fetch so total latency is unchanged
- Game-detail page card text updated; CatalogView (home page) untouched since it only renders \`GameTile\`, not \`ChallengeSummary\`

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 52/52 passing
- [ ] Visit \`/leaderboards/g/Dragon%20Warrior\` after deploy: Get to Level 2 card reads \"3 players · 4 runs\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)