### PR TITLE
feat(website): activity feed leans in — bigger, top, live, annotated

### DIFF
--- a/src/components/AutoRefresh.tsx
+++ b/src/components/AutoRefresh.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+// Periodic router.refresh() so the catalog's recent-activity feed picks
+// up new runs without the visitor manually reloading. Pauses when the
+// tab isn't visible (Chromium throttles intervals there anyway, but
+// being explicit avoids hammering the server with stale-cache requests
+// from background tabs).
+//
+// 30-second cadence is a soft trade — fast enough to feel live during
+// a streamer's session, slow enough that the server isn't refetching
+// every Run row + manifest every couple seconds.
+export function AutoRefresh({ intervalMs = 30000 }: { intervalMs?: number }) {
+  const router = useRouter();
+  useEffect(() => {
+    const tick = () => {
+      if (document.visibilityState === 'visible') router.refresh();
+    };
+    const id = setInterval(tick, intervalMs);
+    return () => clearInterval(id);
+  }, [router, intervalMs]);
+  return null;
+}

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -12,20 +12,26 @@ import {
   type GameSummary,
   type RecentRunEntry,
 } from '@/lib/leaderboard';
+import { AutoRefresh } from '@/components/AutoRefresh';
 
-// Hero + game-tile grid + recent-activity feed. Rendered by both the
+// Hero + recent-activity feed + game-tile grid. Rendered by both the
 // /leaderboards route and the host-aware / route (when served from
 // the legacy leaderboards.retrochallenges.com hostname) so users hit
 // the same UI either way during the flawlessnes.com transition.
+//
+// The feed sits above the game grid because that's the dynamic /
+// addictive part — visitors come back to see what just happened, not
+// to re-browse the same games. AutoRefresh re-pulls every 30s.
 export async function CatalogView() {
   const [stats, games, recent] = await Promise.all([
     getOverallStats(),
     listGames(),
-    getRecentRuns(8),
+    getRecentRuns(20),
   ]);
 
   return (
     <div className="space-y-10">
+      <AutoRefresh intervalMs={30000} />
       <Hero stats={stats} />
 
       {games.length === 0 ? (
@@ -36,8 +42,8 @@ export async function CatalogView() {
         </section>
       ) : (
         <>
-          <GamesSection games={games} />
           {recent.length > 0 && <RecentActivity runs={recent} />}
+          <GamesSection games={games} />
         </>
       )}
     </div>
@@ -173,6 +179,7 @@ function RecentActivity({ runs }: { runs: RecentRunEntry[] }) {
                 <Link href={gameHref(r.game)} className="text-slate-100 hover:text-indigo-300">
                   {r.game}
                 </Link>
+                <ActivityAnnotations run={r} />
               </div>
               <div className="text-xs text-slate-500 mt-0.5">
                 {formatTopMetric(r.score, r.completionTimeFrames)}
@@ -187,4 +194,51 @@ function RecentActivity({ runs }: { runs: RecentRunEntry[] }) {
       </ul>
     </section>
   );
+}
+
+// Tiny inline annotations rendered after the run sentence. Quiet most of
+// the time; lights up when something narratively interesting happened.
+// Order: most prestigious first (first-ever), then PB, then "they're
+// grinding" — keeps the eye-grabbing badges to the left.
+function ActivityAnnotations({ run }: { run: RecentRunEntry }) {
+  return (
+    <>
+      {run.firstEverCompletion && (
+        <span
+          title="First-ever completion of this challenge"
+          className="ml-1.5 text-amber-300"
+          aria-label="first-ever completion"
+        >
+          🥇
+        </span>
+      )}
+      {run.personalBest && !run.firstEverCompletion && (
+        <span
+          title="Personal best on this challenge"
+          className="ml-1.5 text-emerald-300"
+          aria-label="personal best"
+        >
+          🏆
+        </span>
+      )}
+      {run.attemptStreak >= 3 && (
+        <span
+          title={`${run.userName}'s ${ordinal(run.attemptStreak)} attempt on this challenge in the last hour`}
+          className="ml-1.5 text-xs font-medium text-orange-300 bg-orange-500/10 rounded px-1.5 py-0.5 align-middle"
+        >
+          🔁 {run.attemptStreak}× in 1h
+        </span>
+      )}
+    </>
+  );
+}
+
+function ordinal(n: number): string {
+  const last = n % 10;
+  const teen = Math.floor(n / 10) % 10 === 1;
+  if (teen)            return `${n}th`;
+  if (last === 1)      return `${n}st`;
+  if (last === 2)      return `${n}nd`;
+  if (last === 3)      return `${n}rd`;
+  return `${n}th`;
 }

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -283,6 +283,9 @@ export async function getOverallStats(): Promise<{
 }
 
 // Most recent submissions across all challenges, for the activity feed.
+// `firstEverCompletion`, `personalBest`, and `attemptStreak` are storyline
+// flags the renderer turns into emoji annotations so the feed reads as
+// little narratives rather than an opaque list of times.
 export interface RecentRunEntry {
   runId: string;
   game: string;
@@ -293,7 +296,17 @@ export interface RecentRunEntry {
   userId: string;
   userName: string;
   userPictureUrl: string | null;
+  // True when this run is the first time anyone ever cleared this challenge.
+  firstEverCompletion: boolean;
+  // True when this run is strictly better than every prior run by the same
+  // user on the same challenge (under the time-first / score-tiebreak rule).
+  personalBest: boolean;
+  // Count of THIS user's runs on THIS challenge in the last 60 minutes,
+  // including this row itself. ≥3 reads as "they're hammering at it".
+  attemptStreak: number;
 }
+
+const STREAK_WINDOW_MS = 60 * 60 * 1000;  // 1 hour
 
 export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
   const rows = await prisma.run.findMany({
@@ -302,6 +315,7 @@ export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
     take: limit,
     select: {
       id: true,
+      userId: true,
       game: true,
       challengeName: true,
       score: true,
@@ -310,17 +324,77 @@ export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
       user: { select: { id: true, name: true, pictureUrl: true, hasCustomAvatar: true } },
     },
   });
-  return rows.map((r) => ({
-    runId: r.id,
-    game: r.game,
-    challengeName: r.challengeName,
-    score: r.score,
-    completionTimeFrames: r.completionTimeFrames,
-    serverReceivedAt: r.serverReceivedAt,
-    userId: r.user.id,
-    userName: r.user.name,
-    userPictureUrl: effectivePictureUrl(r.user),
-  }));
+
+  // Per-row enrichment: three independent queries fanned out in parallel
+  // for each of the (small) recent set. N+1 with N ≤ ~20 — fine at our
+  // scale; revisit with a window-function aggregation when this hits the
+  // hundreds-of-runs-per-page tier.
+  return Promise.all(
+    rows.map(async (r): Promise<RecentRunEntry> => {
+      const streakSince = new Date(r.serverReceivedAt.getTime() - STREAK_WINDOW_MS);
+
+      const [firstEver, priorBetter, streakCount] = await Promise.all([
+        // Was this the first-ever submission on this (game, challenge)?
+        prisma.run.findFirst({
+          where: {
+            game: r.game,
+            challengeName: r.challengeName,
+            hiddenAt: null,
+            user: { bannedAt: null },
+            serverReceivedAt: { lt: r.serverReceivedAt },
+          },
+          select: { id: true },
+        }),
+        // Did this user have a strictly-better run on this challenge BEFORE
+        // this one? Time-first comparison; null ranks worse than any number.
+        prisma.run.findFirst({
+          where: {
+            userId: r.userId,
+            game: r.game,
+            challengeName: r.challengeName,
+            hiddenAt: null,
+            serverReceivedAt: { lt: r.serverReceivedAt },
+          },
+          orderBy: [
+            { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
+            { score: { sort: 'desc', nulls: 'last' } },
+          ],
+          select: { score: true, completionTimeFrames: true },
+        }),
+        // How many runs has this user had on this challenge within the last
+        // hour, including this one?
+        prisma.run.count({
+          where: {
+            userId: r.userId,
+            game: r.game,
+            challengeName: r.challengeName,
+            hiddenAt: null,
+            serverReceivedAt: { gte: streakSince, lte: r.serverReceivedAt },
+          },
+        }),
+      ]);
+
+      const personalBest = !priorBetter || isBetterRun(
+        { score: r.score, completionTimeFrames: r.completionTimeFrames },
+        priorBetter,
+      );
+
+      return {
+        runId: r.id,
+        game: r.game,
+        challengeName: r.challengeName,
+        score: r.score,
+        completionTimeFrames: r.completionTimeFrames,
+        serverReceivedAt: r.serverReceivedAt,
+        userId: r.user.id,
+        userName: r.user.name,
+        userPictureUrl: effectivePictureUrl(r.user),
+        firstEverCompletion: !firstEver,
+        personalBest,
+        attemptStreak: streakCount,
+      };
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The recent-runs feed is the addictive part of the catalog. Star treatment:

| Change | Before | After |
|---|---|---|
| Position | Bottom of page | **Top**, right after the hero |
| Entries | 8 | **20** |
| Refresh | On nav only | **Auto every 30s** (tab-visible) |
| Annotations | None | 🥇 first-ever / 🏆 PB / 🔁 N× in 1h |

## Annotation rules
- **🥇 First-ever**: this run is the chronologically-first submission anyone has made for this \`(game, challengeName)\`.
- **🏆 Personal best**: this run is strictly better than every prior run by the same user on the same challenge. Suppressed when 🥇 also fires — no double-badge.
- **🔁 N× in 1h**: this user has submitted ≥3 runs on this challenge in the last 60 min, including this one. Reads as "they're hammering at it".

Personal-best comparison reuses the existing \`isBetterRun()\` rule (time-first, score-tiebreak) so ranking semantics stay consistent across the site.

## Performance
\`getRecentRuns\` fans out three sub-queries per row (first-ever check / prior-best lookup / streak count), parallel-\`Promise.all\`'d. 20 rows × 3 = 60 queries — fine at our scale; revisit when this becomes hundreds of runs per page render.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 52/52 passing
- [x] \`npm run build\` — green
- [ ] After deploy: visit \`/leaderboards\`, see 20 recent runs at top with appropriate badges. Sit on the page for 30s — new run from desktop app appears without reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)