### PR TITLE
feat(website): box art on game tiles (libretro-thumbnails)

### DIFF
--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -101,22 +101,42 @@ function GameTile({ game }: { game: GameSummary }) {
   return (
     <Link
       href={gameHref(game.game)}
-      className="group block rounded-lg border border-slate-700 bg-slate-900 p-5 transition-colors hover:border-indigo-500 hover:bg-slate-800"
+      className="group flex gap-3 rounded-lg border border-slate-700 bg-slate-900 p-4 transition-colors hover:border-indigo-500 hover:bg-slate-800"
     >
-      <div className="flex items-start justify-between gap-3">
-        <h3 className="font-display text-lg font-semibold text-white truncate">{game.game}</h3>
-        <span
-          className="shrink-0 rounded-full bg-indigo-500/20 px-2 py-0.5 text-xs font-medium text-indigo-300"
+      {/* Box art on the left — fixed 48×64 (3:4 NES box ratio). The
+          fixed slot keeps the tile size identical whether or not the
+          game ships a boxArtUrl; missing art renders the placeholder. */}
+      {game.boxArtUrl ? (
+        <Image
+          src={game.boxArtUrl}
+          alt=""
+          width={48}
+          height={64}
+          unoptimized
+          className="shrink-0 self-center h-16 w-12 rounded border border-slate-700 object-cover"
+        />
+      ) : (
+        <div
+          className="shrink-0 self-center h-16 w-12 rounded border border-slate-700 bg-slate-800"
           aria-hidden="true"
-        >
-          Browse &rarr;
-        </span>
+        />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="font-display text-lg font-semibold text-white truncate">{game.game}</h3>
+          <span
+            className="shrink-0 rounded-full bg-indigo-500/20 px-2 py-0.5 text-xs font-medium text-indigo-300"
+            aria-hidden="true"
+          >
+            Browse &rarr;
+          </span>
+        </div>
+        <dl className="mt-2 grid grid-cols-3 gap-2 text-center">
+          <TileStat label="challenges" value={game.totalChallenges} />
+          <TileStat label="runs"       value={game.totalRuns} />
+          <TileStat label="players"    value={game.totalPlayers} />
+        </dl>
       </div>
-      <dl className="mt-3 grid grid-cols-3 gap-2 text-center">
-        <TileStat label="challenges" value={game.totalChallenges} />
-        <TileStat label="runs"       value={game.totalRuns} />
-        <TileStat label="players"    value={game.totalPlayers} />
-      </dl>
     </Link>
   );
 }

--- a/src/lib/challenges-manifest.ts
+++ b/src/lib/challenges-manifest.ts
@@ -19,6 +19,8 @@ interface RawManifestChallenge {
 }
 interface RawManifestGame {
   name: string;
+  description?: string;
+  boxArtUrl?: string;
   challenges: RawManifestChallenge[];
 }
 interface RawManifest {
@@ -32,17 +34,28 @@ export interface ChallengeMeta {
   difficulty?: string;
 }
 
+export interface GameMeta {
+  game: string;
+  description?: string;
+  boxArtUrl?: string;
+}
+
+export interface ParsedManifest {
+  challenges: Map<string, ChallengeMeta>;
+  games: Map<string, GameMeta>;
+}
+
 // Map key: `${game}::${challengeName}`. Identical key shape used elsewhere
 // in the app for (game, challenge) tuples — see UserProfile aggregation.
 export function manifestKey(game: string, challengeName: string): string {
   return `${game}::${challengeName}`;
 }
 
-let cache: { meta: Map<string, ChallengeMeta>; expiresAt: number } | null = null;
+let cache: { parsed: ParsedManifest; expiresAt: number } | null = null;
 
-export async function getChallengesManifest(): Promise<Map<string, ChallengeMeta>> {
+async function loadManifest(): Promise<ParsedManifest> {
   const now = Date.now();
-  if (cache && now < cache.expiresAt) return cache.meta;
+  if (cache && now < cache.expiresAt) return cache.parsed;
 
   try {
     const res = await fetch(MANIFEST_URL, {
@@ -51,31 +64,47 @@ export async function getChallengesManifest(): Promise<Map<string, ChallengeMeta
     });
     if (!res.ok) throw new Error(`manifest fetch ${res.status}`);
     const data = (await res.json()) as RawManifest;
-    const meta = parseManifest(data);
-    cache = { meta, expiresAt: now + TTL_MS };
-    return meta;
+    const parsed = parseManifest(data);
+    cache = { parsed, expiresAt: now + TTL_MS };
+    return parsed;
   } catch (err) {
     console.warn(
       '[manifest] fetch failed, serving',
-      cache ? 'stale cache' : 'empty map',
+      cache ? 'stale cache' : 'empty maps',
       ':',
       (err as Error).message,
     );
     // Serve stale rather than empty if we ever had a successful fetch —
     // an outage shouldn't make the navigation regress to flat lists.
-    return cache?.meta ?? new Map();
+    return cache?.parsed ?? { challenges: new Map(), games: new Map() };
   }
 }
 
+export async function getChallengesManifest(): Promise<Map<string, ChallengeMeta>> {
+  return (await loadManifest()).challenges;
+}
+
+export async function getGamesManifest(): Promise<Map<string, GameMeta>> {
+  return (await loadManifest()).games;
+}
+
 // Pure transform — exported so tests can hit it without touching fetch.
-export function parseManifest(data: RawManifest): Map<string, ChallengeMeta> {
-  const out = new Map<string, ChallengeMeta>();
-  if (!data || !Array.isArray(data.games)) return out;
+// Returns both per-challenge AND per-game maps in one pass through the
+// raw manifest tree.
+export function parseManifest(data: RawManifest): ParsedManifest {
+  const challenges = new Map<string, ChallengeMeta>();
+  const games      = new Map<string, GameMeta>();
+  if (!data || !Array.isArray(data.games)) return { challenges, games };
   for (const g of data.games) {
     if (!g || typeof g.name !== 'string' || !Array.isArray(g.challenges)) continue;
+    games.set(g.name, {
+      game: g.name,
+      description: typeof g.description === 'string' ? g.description : undefined,
+      boxArtUrl: typeof g.boxArtUrl === 'string' ? g.boxArtUrl : undefined,
+    });
     for (const c of g.challenges) {
       if (!c || typeof c.name !== 'string') continue;
-      out.set(manifestKey(g.name, c.name), {
+      challenges.set(manifestKey(g.name, c.name), {
         game: g.name,
         challengeName: c.name,
         category: c.category,
@@ -83,7 +112,7 @@ export function parseManifest(data: RawManifest): Map<string, ChallengeMeta> {
       });
     }
   }
-  return out;
+  return { challenges, games };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,4 +1,5 @@
 import { prisma } from './db';
+import { getGamesManifest } from './challenges-manifest';
 
 // Resolve a user's effective avatar URL: if they uploaded a custom one
 // it lives at /api/users/<id>/avatar, otherwise we fall back to whatever
@@ -234,15 +235,22 @@ export interface GameSummary {
   totalChallenges: number;
   totalRuns: number;
   totalPlayers: number;
+  // Pulled from the assets-repo manifest (boxArtUrl per game). Optional
+  // because not every game ships a box-art URL — game tile renders a
+  // text-only fallback when missing.
+  boxArtUrl?: string;
 }
 
 export async function listGames(): Promise<GameSummary[]> {
-  const games = await prisma.run.groupBy({
-    by: ['game'],
-    where: { hiddenAt: null, user: { bannedAt: null } },
-    _count: { _all: true },
-    orderBy: { game: 'asc' },
-  });
+  const [games, manifest] = await Promise.all([
+    prisma.run.groupBy({
+      by: ['game'],
+      where: { hiddenAt: null, user: { bannedAt: null } },
+      _count: { _all: true },
+      orderBy: { game: 'asc' },
+    }),
+    getGamesManifest(),
+  ]);
   return Promise.all(
     games.map(async (g) => {
       const [challengeRows, playerRows] = await Promise.all([
@@ -257,6 +265,7 @@ export async function listGames(): Promise<GameSummary[]> {
       ]);
       return {
         game: g.game,
+        boxArtUrl: manifest.get(g.game)?.boxArtUrl,
         totalChallenges: challengeRows.length,
         totalRuns: g._count._all,
         totalPlayers: playerRows.length,

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -7,11 +7,11 @@ import {
 } from '../src/lib/challenges-manifest';
 
 describe('parseManifest', () => {
-  test('empty / null / malformed input returns empty map', () => {
-    expect(parseManifest(undefined as unknown as { games: never[] }).size).toBe(0);
-    expect(parseManifest(null as unknown as { games: never[] }).size).toBe(0);
-    expect(parseManifest({} as unknown as { games: never[] }).size).toBe(0);
-    expect(parseManifest({ games: 'not an array' } as unknown as { games: never[] }).size).toBe(0);
+  test('empty / null / malformed input returns empty maps', () => {
+    expect(parseManifest(undefined as unknown as { games: never[] }).challenges.size).toBe(0);
+    expect(parseManifest(null as unknown as { games: never[] }).challenges.size).toBe(0);
+    expect(parseManifest({} as unknown as { games: never[] }).challenges.size).toBe(0);
+    expect(parseManifest({ games: 'not an array' } as unknown as { games: never[] }).challenges.size).toBe(0);
   });
 
   test('skips games / challenges with missing or wrong-typed names', () => {
@@ -23,8 +23,8 @@ describe('parseManifest', () => {
         null as unknown as { name: string; challenges: never[] },
       ],
     });
-    expect(m.size).toBe(1);
-    expect(m.get('OK::Real')?.category).toBe('boss');
+    expect(m.challenges.size).toBe(1);
+    expect(m.challenges.get('OK::Real')?.category).toBe('boss');
   });
 
   test('round-trips category and difficulty', () => {
@@ -39,24 +39,51 @@ describe('parseManifest', () => {
         },
       ],
     });
-    expect(m.size).toBe(2);
-    expect(m.get(manifestKey('Castlevania', 'Phantom Bat'))).toEqual({
+    expect(m.challenges.size).toBe(2);
+    expect(m.challenges.get(manifestKey('Castlevania', 'Phantom Bat'))).toEqual({
       game: 'Castlevania',
       challengeName: 'Phantom Bat',
       category: 'boss',
       difficulty: 'Medium',
     });
-    expect(m.get(manifestKey('Castlevania', 'Get 5000 points!'))?.category).toBe('score');
+    expect(m.challenges.get(manifestKey('Castlevania', 'Get 5000 points!'))?.category).toBe('score');
   });
 
   test('absent category / difficulty stays undefined (not coerced to empty string)', () => {
     const m = parseManifest({
       games: [{ name: 'X', challenges: [{ name: 'Y' }] }],
     });
-    const meta = m.get(manifestKey('X', 'Y'));
+    const meta = m.challenges.get(manifestKey('X', 'Y'));
     expect(meta).toBeDefined();
     expect(meta?.category).toBeUndefined();
     expect(meta?.difficulty).toBeUndefined();
+  });
+
+  test('extracts per-game boxArtUrl / description into the games map', () => {
+    const m = parseManifest({
+      games: [
+        {
+          name: 'Castlevania',
+          description: 'Vampires!',
+          boxArtUrl: 'https://example.com/cv.png',
+          challenges: [{ name: 'Phantom Bat' }],
+        },
+        // game without boxArtUrl: still appears in the map, just with
+        // boxArtUrl undefined — game tile renders the no-art fallback.
+        { name: 'Mystery', challenges: [{ name: 'X' }] },
+      ],
+    });
+    expect(m.games.size).toBe(2);
+    expect(m.games.get('Castlevania')).toEqual({
+      game: 'Castlevania',
+      description: 'Vampires!',
+      boxArtUrl: 'https://example.com/cv.png',
+    });
+    expect(m.games.get('Mystery')).toEqual({
+      game: 'Mystery',
+      description: undefined,
+      boxArtUrl: undefined,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
Each game tile leads with a 48×64 box-art thumbnail (NES portrait ratio). Source URLs come from the assets-repo manifest's new \`boxArtUrl\` field per game, pointing at \`raw.githubusercontent.com/libretro-thumbnails\`.

**Why this matters for asset weight:** zero bytes shipped in either repo. Browser lazy-loads each thumb only when the tile is in viewport. GitHub's CDN handles serving, browser cache handles repeat visits. Players never download art for games they don't see.

## Implementation
- \`parseManifest\` refactored to return \`ParsedManifest { challenges, games }\` so per-game metadata (boxArtUrl, description) is available alongside the existing per-challenge metadata
- \`getChallengesManifest\` kept as a back-compat shim; new \`getGamesManifest\` exposes the games map
- \`listGames()\` fans out the manifest fetch in parallel with the existing per-game DB groupBys
- \`GameTile\` renders \`<Image unoptimized>\` for the thumb (skips Next's image processing — libretro URLs aren't on the configured remotePatterns and these are already small enough). Missing-art games fall back to a same-sized placeholder block so tile dimensions stay constant.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 53/53 (one new \`parseManifest\` case)
- [x] \`npm run build\` — green
- [ ] After deploy: \`/leaderboards\` shows box art on Castlevania / Mega Man 2 / Dragon Warrior / Donkey Kong tiles. New games without boxArtUrl render the placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)