### PR TITLE
feat(website): /admin section — dashboard, runs, users, challenges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.8.1",
         "sharp": "^0.34.5",
         "zod": "^3.23.8"
       },
@@ -2076,6 +2077,42 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2116,6 +2153,18 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -2181,6 +2230,69 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
@@ -2333,6 +2445,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -3805,6 +3923,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3933,6 +4060,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4010,6 +4258,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -4398,6 +4652,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -4854,6 +5118,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -5540,6 +5810,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5625,6 +5905,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -8933,8 +9222,8 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -8963,6 +9252,30 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -8984,6 +9297,52 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -9072,6 +9431,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -9992,6 +10357,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -10541,6 +10912,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10589,6 +10969,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
     "sharp": "^0.34.5",
     "zod": "^3.23.8"
   },

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,0 +1,63 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { prisma } from '@/lib/db';
+import { requireAdmin } from '@/lib/auth';
+
+// Server actions used by the admin pages. Each one re-checks
+// requireAdmin() — even though the layout already gated rendering,
+// server actions are individually-callable POST endpoints that bypass
+// the layout, so we must NOT trust the layout-level gate alone.
+
+export async function hideRunAction(runId: string, reason: string | null) {
+  await requireAdmin();
+  await prisma.run.update({
+    where: { id: runId },
+    data: { hiddenAt: new Date(), hiddenReason: reason || null },
+  });
+  revalidatePath('/admin/runs');
+}
+
+export async function unhideRunAction(runId: string) {
+  await requireAdmin();
+  await prisma.run.update({
+    where: { id: runId },
+    data: { hiddenAt: null, hiddenReason: null },
+  });
+  revalidatePath('/admin/runs');
+}
+
+// Hard-delete is destructive but lossless for moderation purposes —
+// the row goes away completely. Most cases should use hide instead;
+// reserve delete for spam / test data / GDPR-style requests.
+export async function deleteRunAction(runId: string) {
+  await requireAdmin();
+  await prisma.run.delete({ where: { id: runId } });
+  revalidatePath('/admin/runs');
+}
+
+export async function banUserAction(userId: string) {
+  const me = await requireAdmin();
+  // Belt-and-suspenders: never let an admin ban themselves and lock
+  // out the admin section. Hardcoded allowlist would let them back in,
+  // but a permanent self-mistake is annoying. Just no.
+  if (userId === me.userId) {
+    throw new Error("Can't ban yourself.");
+  }
+  await prisma.user.update({
+    where: { id: userId },
+    data: { bannedAt: new Date() },
+  });
+  revalidatePath('/admin/users');
+  revalidatePath('/admin');
+}
+
+export async function unbanUserAction(userId: string) {
+  await requireAdmin();
+  await prisma.user.update({
+    where: { id: userId },
+    data: { bannedAt: null },
+  });
+  revalidatePath('/admin/users');
+  revalidatePath('/admin');
+}

--- a/src/app/admin/challenges/page.tsx
+++ b/src/app/admin/challenges/page.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link';
+import { listAdminChallengeStats } from '@/lib/admin';
+import { challengeHref, formatFrames } from '@/lib/leaderboard';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminChallengesPage() {
+  const stats = await listAdminChallengeStats();
+  const now = Date.now();
+
+  return (
+    <div className="space-y-4">
+      <header>
+        <h1 className="font-display text-2xl font-bold text-white">Challenges</h1>
+        <p className="text-sm text-slate-400 mt-1">
+          Read-only stats for every challenge that has at least one run. Challenge
+          definitions live in the assets repo — edit there.
+        </p>
+      </header>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-700 bg-slate-900">
+        <table className="w-full text-sm">
+          <thead className="text-left text-xs uppercase text-slate-500 border-b border-slate-700">
+            <tr>
+              <th className="px-3 py-2">Game / Challenge</th>
+              <th className="px-3 py-2 text-right">Runs</th>
+              <th className="px-3 py-2 text-right">Players</th>
+              <th className="px-3 py-2 text-right">Fastest</th>
+              <th className="px-3 py-2">Held by</th>
+              <th className="px-3 py-2 text-right">Last run</th>
+            </tr>
+          </thead>
+          <tbody>
+            {stats.map((s) => {
+              const daysSince = s.lastRunAt
+                ? Math.floor((now - new Date(s.lastRunAt).getTime()) / (24 * 3600 * 1000))
+                : null;
+              const stale = daysSince !== null && daysSince >= 30;
+              return (
+                <tr key={`${s.game}::${s.challengeName}`} className="border-t border-slate-800">
+                  <td className="px-3 py-2">
+                    <Link
+                      href={challengeHref(s.game, s.challengeName)}
+                      className="text-slate-200 hover:text-indigo-300"
+                    >
+                      <span className="text-slate-500">{s.game}</span>
+                      <span className="mx-1.5 text-slate-700">/</span>
+                      {s.challengeName}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-slate-300 tabular-nums">
+                    {s.runs}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-slate-300 tabular-nums">
+                    {s.players}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-slate-300">
+                    {formatFrames(s.fastestFrames)}
+                  </td>
+                  <td className="px-3 py-2 text-slate-400">
+                    {s.fastestPlayer ?? '—'}
+                  </td>
+                  <td className={`px-3 py-2 text-right text-xs whitespace-nowrap ${stale ? 'text-amber-400' : 'text-slate-500'}`}>
+                    {s.lastRunAt
+                      ? `${new Date(s.lastRunAt).toLocaleDateString()}${daysSince ? ` (${daysSince}d ago)` : ''}`
+                      : '—'}
+                  </td>
+                </tr>
+              );
+            })}
+            {stats.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-3 py-8 text-center text-slate-500">
+                  No challenges have runs yet.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-xs text-slate-500">
+        Yellow "last run" highlights challenges with no submissions in 30+ days — possibly broken or forgotten.
+      </p>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import { requireAdmin } from '@/lib/auth';
+
+// Wraps every /admin route. requireAdmin() throws via notFound() if the
+// signed-in user isn't on the allowlist — anyone fishing for /admin sees
+// a 404 rather than a permission-denied page.
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  await requireAdmin();
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-[180px,1fr] gap-6">
+      <aside>
+        <h2 className="font-display text-sm uppercase tracking-wider text-slate-500 mb-3">
+          Admin
+        </h2>
+        <nav className="space-y-1 text-sm">
+          <AdminNavLink href="/admin">           Dashboard   </AdminNavLink>
+          <AdminNavLink href="/admin/runs">      Runs        </AdminNavLink>
+          <AdminNavLink href="/admin/users">     Users       </AdminNavLink>
+          <AdminNavLink href="/admin/challenges">Challenges  </AdminNavLink>
+        </nav>
+        <div className="mt-6 text-xs text-slate-600">
+          Signed in as admin. Public links above the page header still
+          work normally for you.
+        </div>
+      </aside>
+      <main className="min-w-0">{children}</main>
+    </div>
+  );
+}
+
+function AdminNavLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <Link
+      href={href}
+      className="block rounded-md px-3 py-2 text-slate-300 hover:bg-slate-800 hover:text-white"
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,141 @@
+import Link from 'next/link';
+import {
+  getAdminKpis,
+  getActivityHeatmap,
+  getSubmissionsByDay,
+  getSubmissionsByHour,
+  getTopChallenges,
+  getTopPlayers,
+} from '@/lib/admin';
+import { challengeHref, userProfileHref } from '@/lib/leaderboard';
+import {
+  ActivityHeatmap,
+  RankBar,
+  SubmissionsLine,
+} from '@/components/admin/AdminCharts';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminDashboardPage() {
+  const [kpis, byHour, byDay, topChallenges, topPlayers, heatmap] = await Promise.all([
+    getAdminKpis(),
+    getSubmissionsByHour(24),
+    getSubmissionsByDay(30),
+    getTopChallenges(10),
+    getTopPlayers(10),
+    getActivityHeatmap(12),
+  ]);
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <h1 className="font-display text-2xl font-bold text-white">Dashboard</h1>
+        <p className="text-sm text-slate-400 mt-1">
+          Live snapshot of activity, popular challenges, and the players driving them.
+        </p>
+      </header>
+
+      <section className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <Kpi label="users"        value={kpis.totalUsers}     sub={kpis.bannedUsers > 0 ? `${kpis.bannedUsers} banned` : undefined} />
+        <Kpi label="runs"         value={kpis.totalRuns}      sub={kpis.hiddenRuns > 0 ? `${kpis.hiddenRuns} hidden` : undefined} />
+        <Kpi label="last 24h"     value={kpis.runsLast24h}    sub={`${kpis.runsLast7d} in last 7d`} />
+        <Kpi label="new players"  value={kpis.newUsersLast7d} sub="last 7 days" />
+      </section>
+
+      <section>
+        <h2 className="font-display text-lg font-semibold text-white mb-2">Submissions — last 24 hours</h2>
+        <div className="rounded-lg border border-slate-700 bg-slate-900 p-3">
+          <SubmissionsLine data={byHour} />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="font-display text-lg font-semibold text-white mb-2">Submissions — last 30 days</h2>
+        <div className="rounded-lg border border-slate-700 bg-slate-900 p-3">
+          <SubmissionsLine data={byDay} />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="font-display text-lg font-semibold text-white mb-2">Activity heatmap (last 12 weeks)</h2>
+        <p className="text-xs text-slate-500 mb-2">
+          Day-of-week × hour of submission. Bigger / brighter dot = more runs in that slot.
+        </p>
+        <div className="rounded-lg border border-slate-700 bg-slate-900 p-3">
+          <ActivityHeatmap data={heatmap} />
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div>
+          <h2 className="font-display text-lg font-semibold text-white mb-2">Top 10 challenges by runs</h2>
+          <div className="rounded-lg border border-slate-700 bg-slate-900 p-3">
+            <RankBar
+              data={topChallenges.map((c) => ({
+                label: truncate(c.challengeName, 22),
+                value: c.runs,
+              }))}
+            />
+            <ul className="mt-2 space-y-1 text-xs text-slate-500">
+              {topChallenges.map((c) => (
+                <li key={`${c.game}::${c.challengeName}`} className="flex items-center justify-between gap-2">
+                  <Link
+                    href={challengeHref(c.game, c.challengeName)}
+                    className="truncate hover:text-indigo-300"
+                  >
+                    {c.game} — {c.challengeName}
+                  </Link>
+                  <span className="shrink-0 tabular-nums">
+                    {c.runs} runs · {c.players} players
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <div>
+          <h2 className="font-display text-lg font-semibold text-white mb-2">Top 10 players by runs</h2>
+          <div className="rounded-lg border border-slate-700 bg-slate-900 p-3">
+            <RankBar
+              data={topPlayers.map((p) => ({
+                label: truncate(p.bannedAt ? `${p.name} (banned)` : p.name, 22),
+                value: p.runs,
+              }))}
+            />
+            <ul className="mt-2 space-y-1 text-xs text-slate-500">
+              {topPlayers.map((p) => (
+                <li key={p.userId} className="flex items-center justify-between gap-2">
+                  <Link href={userProfileHref(p.userId)} className="truncate hover:text-indigo-300">
+                    {p.name}
+                    {p.bannedAt && (
+                      <span className="ml-2 text-red-400">(banned)</span>
+                    )}
+                  </Link>
+                  <span className="shrink-0 tabular-nums">
+                    {p.runs} runs · {p.challenges} challenges
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function Kpi({ label, value, sub }: { label: string; value: number; sub?: string }) {
+  return (
+    <div className="rounded-lg border border-slate-700 bg-slate-900 px-4 py-3">
+      <div className="font-display text-3xl font-bold text-white tabular-nums">
+        {value.toLocaleString()}
+      </div>
+      <div className="text-xs uppercase text-slate-500 mt-1">{label}</div>
+      {sub && <div className="text-xs text-slate-600 mt-0.5">{sub}</div>}
+    </div>
+  );
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + '…' : s;
+}

--- a/src/app/admin/runs/page.tsx
+++ b/src/app/admin/runs/page.tsx
@@ -1,0 +1,223 @@
+import Link from 'next/link';
+import {
+  challengeHref,
+  formatFrames,
+  userProfileHref,
+} from '@/lib/leaderboard';
+import { listAdminRuns } from '@/lib/admin';
+import {
+  hideRunAction,
+  unhideRunAction,
+  deleteRunAction,
+} from '@/app/admin/actions';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  searchParams: Promise<{
+    hidden?: string;
+    game?: string;
+    userId?: string;
+    page?: string;
+  }>;
+}
+
+const PAGE_SIZE = 50;
+
+export default async function AdminRunsPage({ searchParams }: PageProps) {
+  const sp = await searchParams;
+  const hidden: 'all' | 'visible' | 'hidden' =
+    sp.hidden === 'visible' ? 'visible' :
+    sp.hidden === 'hidden'  ? 'hidden'  : 'all';
+  const game   = sp.game?.trim() || undefined;
+  const userId = sp.userId?.trim() || undefined;
+  const page   = Math.max(0, parseInt(sp.page ?? '0', 10) || 0);
+
+  const rows = await listAdminRuns({
+    take: PAGE_SIZE,
+    skip: page * PAGE_SIZE,
+    game,
+    userId,
+    hidden,
+  });
+
+  return (
+    <div className="space-y-4">
+      <header>
+        <h1 className="font-display text-2xl font-bold text-white">Runs</h1>
+        <p className="text-sm text-slate-400 mt-1">
+          Most recent first. Hide removes from public leaderboards (soft); restore brings back; delete is permanent.
+        </p>
+      </header>
+
+      <Filters hidden={hidden} game={game} userId={userId} />
+
+      <div className="overflow-x-auto rounded-lg border border-slate-700 bg-slate-900">
+        <table className="w-full text-sm">
+          <thead className="text-left text-xs uppercase text-slate-500 border-b border-slate-700">
+            <tr>
+              <th className="px-3 py-2">When</th>
+              <th className="px-3 py-2">Player</th>
+              <th className="px-3 py-2">Game / Challenge</th>
+              <th className="px-3 py-2 text-right">Score</th>
+              <th className="px-3 py-2 text-right">Time</th>
+              <th className="px-3 py-2">State</th>
+              <th className="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className={r.hiddenAt ? 'border-t border-slate-800 opacity-60' : 'border-t border-slate-800'}>
+                <td className="px-3 py-2 text-xs text-slate-500 whitespace-nowrap">
+                  {new Date(r.serverReceivedAt).toLocaleString(undefined, {
+                    month: 'short', day: 'numeric',
+                    hour: '2-digit', minute: '2-digit',
+                  })}
+                </td>
+                <td className="px-3 py-2">
+                  <Link
+                    href={userProfileHref(r.user.id)}
+                    className="text-slate-200 hover:text-indigo-300"
+                  >
+                    {r.user.name}
+                  </Link>
+                  {r.user.bannedAt && (
+                    <span className="ml-2 text-xs text-red-400">banned</span>
+                  )}
+                </td>
+                <td className="px-3 py-2">
+                  <Link
+                    href={challengeHref(r.game, r.challengeName)}
+                    className="text-slate-200 hover:text-indigo-300"
+                  >
+                    {r.game} — {r.challengeName}
+                  </Link>
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-slate-300">
+                  {r.score != null ? r.score.toLocaleString() : '—'}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-slate-300">
+                  {formatFrames(r.completionTimeFrames)}
+                </td>
+                <td className="px-3 py-2 text-xs">
+                  {r.hiddenAt
+                    ? <span className="text-amber-300">hidden{r.hiddenReason ? `: ${r.hiddenReason}` : ''}</span>
+                    : <span className="text-emerald-300">live</span>}
+                </td>
+                <td className="px-3 py-2 text-right whitespace-nowrap">
+                  {r.hiddenAt ? (
+                    <form
+                      action={async () => { 'use server'; await unhideRunAction(r.id); }}
+                      className="inline"
+                    >
+                      <ActionButton type="submit" variant="ok">Restore</ActionButton>
+                    </form>
+                  ) : (
+                    <form
+                      action={async (data) => {
+                        'use server';
+                        await hideRunAction(r.id, (data.get('reason') as string) || null);
+                      }}
+                      className="inline"
+                    >
+                      <input type="hidden" name="reason" value="" />
+                      <ActionButton type="submit" variant="warn">Hide</ActionButton>
+                    </form>
+                  )}
+                  <form
+                    action={async () => { 'use server'; await deleteRunAction(r.id); }}
+                    className="inline ml-1"
+                  >
+                    <ActionButton type="submit" variant="danger">Delete</ActionButton>
+                  </form>
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-3 py-8 text-center text-slate-500">
+                  No runs match these filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <Pagination page={page} hasMore={rows.length === PAGE_SIZE} hidden={hidden} game={game} userId={userId} />
+    </div>
+  );
+}
+
+function Filters({ hidden, game, userId }: { hidden: string; game?: string; userId?: string }) {
+  return (
+    <form className="flex flex-wrap items-center gap-2 text-xs">
+      <select
+        name="hidden"
+        defaultValue={hidden}
+        className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200"
+      >
+        <option value="all">all runs</option>
+        <option value="visible">visible only</option>
+        <option value="hidden">hidden only</option>
+      </select>
+      <input
+        type="text"
+        name="game"
+        placeholder="game name"
+        defaultValue={game ?? ''}
+        className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200"
+      />
+      <input
+        type="text"
+        name="userId"
+        placeholder="user id"
+        defaultValue={userId ?? ''}
+        className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200 w-72"
+      />
+      <button
+        type="submit"
+        className="rounded-md bg-indigo-500 px-3 py-1 text-white font-medium hover:bg-indigo-600"
+      >
+        Filter
+      </button>
+    </form>
+  );
+}
+
+function Pagination({ page, hasMore, hidden, game, userId }: { page: number; hasMore: boolean; hidden: string; game?: string; userId?: string }) {
+  const params = (n: number) => {
+    const sp = new URLSearchParams();
+    if (hidden !== 'all') sp.set('hidden', hidden);
+    if (game)   sp.set('game', game);
+    if (userId) sp.set('userId', userId);
+    if (n > 0)  sp.set('page', String(n));
+    return sp.toString() ? `?${sp.toString()}` : '';
+  };
+  return (
+    <div className="flex items-center justify-between text-xs text-slate-500">
+      <span>Page {page + 1}</span>
+      <div className="space-x-2">
+        {page > 0 && (
+          <Link href={`/admin/runs${params(page - 1)}`} className="hover:text-slate-200">← Prev</Link>
+        )}
+        {hasMore && (
+          <Link href={`/admin/runs${params(page + 1)}`} className="hover:text-slate-200">Next →</Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ActionButton({ type, variant, children }: {
+  type?: 'button' | 'submit';
+  variant: 'ok' | 'warn' | 'danger';
+  children: React.ReactNode;
+}) {
+  const base = 'rounded-md px-2 py-1 text-xs font-medium';
+  const palette =
+    variant === 'ok'     ? 'bg-emerald-500/20 text-emerald-300 hover:bg-emerald-500/30' :
+    variant === 'warn'   ? 'bg-amber-500/20 text-amber-300 hover:bg-amber-500/30'       :
+                           'bg-red-500/20 text-red-300 hover:bg-red-500/30';
+  return <button type={type ?? 'button'} className={`${base} ${palette}`}>{children}</button>;
+}

--- a/src/app/admin/users/[userId]/page.tsx
+++ b/src/app/admin/users/[userId]/page.tsx
@@ -1,0 +1,162 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { prisma } from '@/lib/db';
+import { challengeHref, formatFrames, userProfileHref } from '@/lib/leaderboard';
+import { listAdminRuns } from '@/lib/admin';
+import {
+  banUserAction,
+  unbanUserAction,
+  hideRunAction,
+  unhideRunAction,
+  deleteRunAction,
+} from '@/app/admin/actions';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: Promise<{ userId: string }>;
+}
+
+export default async function AdminUserDrillPage({ params }: PageProps) {
+  const { userId } = await params;
+  const [user, runs] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true, name: true, email: true, googleSub: true,
+        createdAt: true, bannedAt: true, hasCustomAvatar: true,
+        _count: { select: { runs: true } },
+      },
+    }),
+    listAdminRuns({ userId, take: 100, hidden: 'all' }),
+  ]);
+  if (!user) notFound();
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-baseline justify-between gap-3">
+        <div>
+          <h1 className="font-display text-2xl font-bold text-white">{user.name}</h1>
+          <p className="text-xs text-slate-500 font-mono mt-1">
+            {user.email} · joined {new Date(user.createdAt).toLocaleDateString()}
+          </p>
+        </div>
+        <div className="text-right space-x-2">
+          <Link href={userProfileHref(user.id)} className="text-xs text-slate-400 hover:text-slate-200">
+            Public profile →
+          </Link>
+          {user.bannedAt ? (
+            <form
+              action={async () => { 'use server'; await unbanUserAction(user.id); }}
+              className="inline"
+            >
+              <button type="submit" className="rounded-md bg-emerald-500/20 px-3 py-1.5 text-xs font-medium text-emerald-300 hover:bg-emerald-500/30">
+                Unban user
+              </button>
+            </form>
+          ) : (
+            <form
+              action={async () => { 'use server'; await banUserAction(user.id); }}
+              className="inline"
+            >
+              <button type="submit" className="rounded-md bg-red-500/20 px-3 py-1.5 text-xs font-medium text-red-300 hover:bg-red-500/30">
+                Ban user
+              </button>
+            </form>
+          )}
+        </div>
+      </header>
+
+      <section className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
+        <KV label="user.id">       {user.id}                            </KV>
+        <KV label="googleSub">     {user.googleSub}                     </KV>
+        <KV label="custom avatar"> {user.hasCustomAvatar ? 'yes' : 'no'} </KV>
+        <KV label="state">         {user.bannedAt ? 'banned' : 'active'} </KV>
+      </section>
+
+      <section>
+        <h2 className="font-display text-lg font-semibold text-white mb-2">
+          Runs ({user._count.runs})
+        </h2>
+        <p className="text-xs text-slate-500 mb-2">Showing the most-recent 100.</p>
+        <div className="overflow-x-auto rounded-lg border border-slate-700 bg-slate-900">
+          <table className="w-full text-sm">
+            <thead className="text-left text-xs uppercase text-slate-500 border-b border-slate-700">
+              <tr>
+                <th className="px-3 py-2">When</th>
+                <th className="px-3 py-2">Game / Challenge</th>
+                <th className="px-3 py-2 text-right">Score</th>
+                <th className="px-3 py-2 text-right">Time</th>
+                <th className="px-3 py-2">State</th>
+                <th className="px-3 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runs.map((r) => (
+                <tr key={r.id} className={r.hiddenAt ? 'border-t border-slate-800 opacity-60' : 'border-t border-slate-800'}>
+                  <td className="px-3 py-2 text-xs text-slate-500 whitespace-nowrap">
+                    {new Date(r.serverReceivedAt).toLocaleString(undefined, {
+                      month: 'short', day: 'numeric',
+                      hour: '2-digit', minute: '2-digit',
+                    })}
+                  </td>
+                  <td className="px-3 py-2">
+                    <Link
+                      href={challengeHref(r.game, r.challengeName)}
+                      className="text-slate-200 hover:text-indigo-300"
+                    >
+                      {r.game} — {r.challengeName}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-slate-300">
+                    {r.score != null ? r.score.toLocaleString() : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-slate-300">
+                    {formatFrames(r.completionTimeFrames)}
+                  </td>
+                  <td className="px-3 py-2 text-xs">
+                    {r.hiddenAt
+                      ? <span className="text-amber-300">hidden</span>
+                      : <span className="text-emerald-300">live</span>}
+                  </td>
+                  <td className="px-3 py-2 text-right whitespace-nowrap">
+                    {r.hiddenAt ? (
+                      <form action={async () => { 'use server'; await unhideRunAction(r.id); }} className="inline">
+                        <button type="submit" className="rounded-md bg-emerald-500/20 px-2 py-1 text-xs font-medium text-emerald-300 hover:bg-emerald-500/30">Restore</button>
+                      </form>
+                    ) : (
+                      <form action={async () => { 'use server'; await hideRunAction(r.id, null); }} className="inline">
+                        <button type="submit" className="rounded-md bg-amber-500/20 px-2 py-1 text-xs font-medium text-amber-300 hover:bg-amber-500/30">Hide</button>
+                      </form>
+                    )}
+                    <form action={async () => { 'use server'; await deleteRunAction(r.id); }} className="inline ml-1">
+                      <button type="submit" className="rounded-md bg-red-500/20 px-2 py-1 text-xs font-medium text-red-300 hover:bg-red-500/30">Delete</button>
+                    </form>
+                  </td>
+                </tr>
+              ))}
+              {runs.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-3 py-6 text-center text-slate-500">
+                    This user has no runs.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function KV({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2">
+      <div className="text-xs uppercase text-slate-500">{label}</div>
+      <div className="font-mono text-xs text-slate-300 mt-0.5 truncate" title={String(children)}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link';
+import { listAdminUsers } from '@/lib/admin';
+import { userProfileHref } from '@/lib/leaderboard';
+import { banUserAction, unbanUserAction } from '@/app/admin/actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminUsersPage() {
+  const users = await listAdminUsers();
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-baseline justify-between">
+        <div>
+          <h1 className="font-display text-2xl font-bold text-white">Users</h1>
+          <p className="text-sm text-slate-400 mt-1">
+            Newest first. Ban hides their runs from public leaderboards (the rows
+            stay in the DB so you can unban without data loss).
+          </p>
+        </div>
+        <span className="text-xs text-slate-500">{users.length} total</span>
+      </header>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-700 bg-slate-900">
+        <table className="w-full text-sm">
+          <thead className="text-left text-xs uppercase text-slate-500 border-b border-slate-700">
+            <tr>
+              <th className="px-3 py-2">Name</th>
+              <th className="px-3 py-2 hidden sm:table-cell">Email</th>
+              <th className="px-3 py-2 hidden md:table-cell">Joined</th>
+              <th className="px-3 py-2 hidden md:table-cell">Last run</th>
+              <th className="px-3 py-2 text-right">Runs</th>
+              <th className="px-3 py-2">State</th>
+              <th className="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.id} className={u.bannedAt ? 'border-t border-slate-800 opacity-60' : 'border-t border-slate-800'}>
+                <td className="px-3 py-2">
+                  <Link href={userProfileHref(u.id)} className="text-slate-200 hover:text-indigo-300">
+                    {u.name}
+                  </Link>
+                  <Link
+                    href={`/admin/users/${u.id}`}
+                    className="ml-2 text-xs text-indigo-300 hover:text-indigo-200"
+                  >
+                    drill →
+                  </Link>
+                </td>
+                <td className="px-3 py-2 text-xs text-slate-500 hidden sm:table-cell font-mono">
+                  {u.email}
+                </td>
+                <td className="px-3 py-2 text-xs text-slate-500 hidden md:table-cell whitespace-nowrap">
+                  {new Date(u.createdAt).toLocaleDateString()}
+                </td>
+                <td className="px-3 py-2 text-xs text-slate-500 hidden md:table-cell whitespace-nowrap">
+                  {u.lastRunAt ? new Date(u.lastRunAt).toLocaleDateString() : '—'}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-slate-300 tabular-nums">
+                  {u.totalRuns}
+                </td>
+                <td className="px-3 py-2 text-xs">
+                  {u.bannedAt
+                    ? <span className="text-red-400">banned</span>
+                    : <span className="text-emerald-300">active</span>}
+                </td>
+                <td className="px-3 py-2 text-right whitespace-nowrap">
+                  {u.bannedAt ? (
+                    <form
+                      action={async () => { 'use server'; await unbanUserAction(u.id); }}
+                      className="inline"
+                    >
+                      <ActionButton type="submit" variant="ok">Unban</ActionButton>
+                    </form>
+                  ) : (
+                    <form
+                      action={async () => { 'use server'; await banUserAction(u.id); }}
+                      className="inline"
+                    >
+                      <ActionButton type="submit" variant="danger">Ban</ActionButton>
+                    </form>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function ActionButton({ type, variant, children }: {
+  type?: 'button' | 'submit';
+  variant: 'ok' | 'warn' | 'danger';
+  children: React.ReactNode;
+}) {
+  const base = 'rounded-md px-2 py-1 text-xs font-medium';
+  const palette =
+    variant === 'ok'     ? 'bg-emerald-500/20 text-emerald-300 hover:bg-emerald-500/30' :
+    variant === 'warn'   ? 'bg-amber-500/20 text-amber-300 hover:bg-amber-500/30'       :
+                           'bg-red-500/20 text-red-300 hover:bg-red-500/30';
+  return <button type={type ?? 'button'} className={`${base} ${palette}`}>{children}</button>;
+}

--- a/src/components/admin/AdminCharts.tsx
+++ b/src/components/admin/AdminCharts.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import {
+  Bar, BarChart,
+  CartesianGrid, Cell,
+  Line, LineChart,
+  ResponsiveContainer,
+  Scatter, ScatterChart, ZAxis,
+  Tooltip,
+  XAxis, YAxis,
+} from 'recharts';
+
+const RED        = '#B53120';
+const RED_LIGHT  = '#E40058';
+const GRAY_LINE  = '#3D3D3D';
+const GRAY_TEXT  = '#7C7C7C';
+
+const tooltipStyle = {
+  backgroundColor: '#1A1A1A',
+  border: '1px solid #545454',
+  borderRadius: '6px',
+  color: '#E0E0E0',
+};
+
+interface TimeBucket { label: string; count: number; }
+
+export function SubmissionsLine({ data, height = 200 }: { data: TimeBucket[]; height?: number }) {
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <LineChart data={data} margin={{ top: 8, right: 16, bottom: 8, left: -20 }}>
+        <CartesianGrid stroke={GRAY_LINE} strokeDasharray="3 3" />
+        <XAxis dataKey="label" stroke={GRAY_TEXT} tick={{ fontSize: 11 }} />
+        <YAxis stroke={GRAY_TEXT} tick={{ fontSize: 11 }} allowDecimals={false} />
+        <Tooltip contentStyle={tooltipStyle} cursor={{ stroke: RED_LIGHT, strokeWidth: 1 }} />
+        <Line
+          type="monotone"
+          dataKey="count"
+          stroke={RED_LIGHT}
+          strokeWidth={2}
+          dot={{ r: 2, fill: RED_LIGHT }}
+          activeDot={{ r: 4 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+interface RankRow { label: string; value: number; }
+
+export function RankBar({ data, height = 220 }: { data: RankRow[]; height?: number }) {
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart data={data} layout="vertical" margin={{ top: 4, right: 16, bottom: 4, left: 0 }}>
+        <CartesianGrid stroke={GRAY_LINE} strokeDasharray="3 3" horizontal={false} />
+        <XAxis type="number" stroke={GRAY_TEXT} tick={{ fontSize: 11 }} allowDecimals={false} />
+        <YAxis
+          type="category"
+          dataKey="label"
+          stroke={GRAY_TEXT}
+          width={140}
+          tick={{ fontSize: 11, fill: '#BCBCBC' }}
+        />
+        <Tooltip contentStyle={tooltipStyle} cursor={{ fill: 'rgba(228, 0, 88, 0.1)' }} />
+        <Bar dataKey="value" fill={RED} radius={[0, 3, 3, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+interface HeatmapCell { day: number; dayLabel: string; hour: number; count: number; }
+
+// Day-of-week × hour heatmap rendered as a ScatterChart with dot size
+// proportional to activity. Reads as a heatmap at our densities; avoids
+// pulling in a separate heatmap library.
+export function ActivityHeatmap({ data, height = 240 }: { data: HeatmapCell[]; height?: number }) {
+  const maxCount = Math.max(1, ...data.map((d) => d.count));
+  const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <ScatterChart margin={{ top: 8, right: 16, bottom: 16, left: 0 }}>
+        <CartesianGrid stroke={GRAY_LINE} strokeDasharray="3 3" />
+        <XAxis
+          type="number"
+          dataKey="hour"
+          name="Hour"
+          domain={[-0.5, 23.5]}
+          ticks={[0, 3, 6, 9, 12, 15, 18, 21]}
+          stroke={GRAY_TEXT}
+          tick={{ fontSize: 11 }}
+        />
+        <YAxis
+          type="number"
+          dataKey="day"
+          name="Day"
+          domain={[-0.5, 6.5]}
+          ticks={[0, 1, 2, 3, 4, 5, 6]}
+          tickFormatter={(v: number) => dayLabels[v] ?? ''}
+          stroke={GRAY_TEXT}
+          tick={{ fontSize: 11, fill: '#BCBCBC' }}
+          width={32}
+          reversed
+        />
+        <ZAxis
+          type="number"
+          dataKey="count"
+          range={[0, 360]}
+          domain={[0, maxCount]}
+        />
+        <Tooltip
+          contentStyle={tooltipStyle}
+          cursor={{ strokeDasharray: '3 3', stroke: RED_LIGHT }}
+          formatter={(value, name) =>
+            name === 'count' ? [`${value} runs`, 'submissions'] : value
+          }
+          labelFormatter={() => ''}
+        />
+        <Scatter data={data} fill={RED}>
+          {data.map((d, i) => (
+            <Cell
+              key={i}
+              fill={d.count === 0 ? '#2C2C2C' : RED}
+              fillOpacity={d.count === 0 ? 0.4 : 0.45 + 0.55 * (d.count / maxCount)}
+            />
+          ))}
+        </Scatter>
+      </ScatterChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,370 @@
+// Server-side data layer for the /admin section. Only imported from
+// admin pages and admin server actions — every function here assumes
+// requireAdmin() has already gated the caller. None of these queries
+// filter by hiddenAt / bannedAt because admins want to see everything.
+
+import { prisma } from '@/lib/db';
+
+// ---------------------------------------------------------------------------
+// Dashboard KPIs
+// ---------------------------------------------------------------------------
+export interface AdminKpis {
+  totalUsers: number;
+  bannedUsers: number;
+  totalRuns: number;
+  hiddenRuns: number;
+  runsLast24h: number;
+  runsLast7d: number;
+  newUsersLast7d: number;
+}
+
+export async function getAdminKpis(): Promise<AdminKpis> {
+  const now = new Date();
+  const dayAgo  = new Date(now.getTime() - 24 * 3600 * 1000);
+  const weekAgo = new Date(now.getTime() - 7 * 24 * 3600 * 1000);
+
+  const [
+    totalUsers, bannedUsers,
+    totalRuns,  hiddenRuns,
+    runsLast24h, runsLast7d, newUsersLast7d,
+  ] = await Promise.all([
+    prisma.user.count(),
+    prisma.user.count({ where: { bannedAt: { not: null } } }),
+    prisma.run.count(),
+    prisma.run.count({ where: { hiddenAt: { not: null } } }),
+    prisma.run.count({ where: { serverReceivedAt: { gte: dayAgo } } }),
+    prisma.run.count({ where: { serverReceivedAt: { gte: weekAgo } } }),
+    prisma.user.count({ where: { createdAt: { gte: weekAgo } } }),
+  ]);
+
+  return {
+    totalUsers, bannedUsers, totalRuns, hiddenRuns,
+    runsLast24h, runsLast7d, newUsersLast7d,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Submissions over time
+// ---------------------------------------------------------------------------
+// Two views: per-hour for the last 24h (granular live activity) and
+// per-day for the last 30d (trend). Both bucketed in JS rather than via
+// SQL date_trunc so we don't depend on Prisma raw queries / Postgres
+// timezones — fine for the volumes we're at.
+
+export interface TimeBucket { label: string; t: Date; count: number; }
+
+export async function getSubmissionsByHour(hours = 24): Promise<TimeBucket[]> {
+  const now = new Date();
+  const start = new Date(now.getTime() - hours * 3600 * 1000);
+  const rows = await prisma.run.findMany({
+    where: { serverReceivedAt: { gte: start } },
+    select: { serverReceivedAt: true },
+    orderBy: { serverReceivedAt: 'asc' },
+  });
+  // Bucket each row into a per-hour slot keyed off the bucket-start ms.
+  const buckets = new Map<number, number>();
+  // Pre-seed every hour bucket so quiet hours render as a 0-bar instead
+  // of a gap in the chart.
+  for (let i = 0; i < hours; i++) {
+    const t = new Date(now.getTime() - (hours - 1 - i) * 3600 * 1000);
+    t.setMinutes(0, 0, 0);
+    buckets.set(t.getTime(), 0);
+  }
+  for (const r of rows) {
+    const t = new Date(r.serverReceivedAt);
+    t.setMinutes(0, 0, 0);
+    const k = t.getTime();
+    buckets.set(k, (buckets.get(k) ?? 0) + 1);
+  }
+  return Array.from(buckets.entries()).map(([k, count]) => {
+    const t = new Date(k);
+    const label = t.toLocaleTimeString(undefined, { hour: 'numeric' });
+    return { label, t, count };
+  }).sort((a, b) => a.t.getTime() - b.t.getTime());
+}
+
+export async function getSubmissionsByDay(days = 30): Promise<TimeBucket[]> {
+  const now = new Date();
+  const start = new Date(now.getTime() - days * 24 * 3600 * 1000);
+  const rows = await prisma.run.findMany({
+    where: { serverReceivedAt: { gte: start } },
+    select: { serverReceivedAt: true },
+  });
+  const buckets = new Map<number, number>();
+  for (let i = 0; i < days; i++) {
+    const t = new Date(now.getTime() - (days - 1 - i) * 24 * 3600 * 1000);
+    t.setHours(0, 0, 0, 0);
+    buckets.set(t.getTime(), 0);
+  }
+  for (const r of rows) {
+    const t = new Date(r.serverReceivedAt);
+    t.setHours(0, 0, 0, 0);
+    const k = t.getTime();
+    if (buckets.has(k)) buckets.set(k, (buckets.get(k) ?? 0) + 1);
+  }
+  return Array.from(buckets.entries()).map(([k, count]) => {
+    const t = new Date(k);
+    const label = t.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    return { label, t, count };
+  }).sort((a, b) => a.t.getTime() - b.t.getTime());
+}
+
+// ---------------------------------------------------------------------------
+// Top-N rankings
+// ---------------------------------------------------------------------------
+export interface ChallengeRank {
+  game: string;
+  challengeName: string;
+  runs: number;
+  players: number;
+}
+
+export async function getTopChallenges(limit = 10): Promise<ChallengeRank[]> {
+  const groups = await prisma.run.groupBy({
+    by: ['game', 'challengeName'],
+    _count: { _all: true },
+    orderBy: { _count: { id: 'desc' } },
+    take: limit,
+  });
+  // Distinct-player count per (game, challenge). N+1 with N = limit; fine.
+  return Promise.all(
+    groups.map(async (g) => {
+      const players = await prisma.run.groupBy({
+        by: ['userId'],
+        where: { game: g.game, challengeName: g.challengeName },
+      });
+      return {
+        game: g.game,
+        challengeName: g.challengeName,
+        runs: g._count._all,
+        players: players.length,
+      };
+    }),
+  );
+}
+
+export interface PlayerRank {
+  userId: string;
+  name: string;
+  runs: number;
+  challenges: number;
+  bannedAt: Date | null;
+}
+
+export async function getTopPlayers(limit = 10): Promise<PlayerRank[]> {
+  const groups = await prisma.run.groupBy({
+    by: ['userId'],
+    _count: { _all: true },
+    orderBy: { _count: { id: 'desc' } },
+    take: limit,
+  });
+  return Promise.all(
+    groups.map(async (g) => {
+      const [user, challengeGroups] = await Promise.all([
+        prisma.user.findUnique({
+          where: { id: g.userId },
+          select: { name: true, bannedAt: true },
+        }),
+        prisma.run.groupBy({
+          by: ['game', 'challengeName'],
+          where: { userId: g.userId },
+        }),
+      ]);
+      return {
+        userId: g.userId,
+        name: user?.name ?? '(deleted user)',
+        runs: g._count._all,
+        challenges: challengeGroups.length,
+        bannedAt: user?.bannedAt ?? null,
+      };
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Day-of-week × hour activity heatmap
+// ---------------------------------------------------------------------------
+// 7 rows (Sun..Sat) × 24 cols (0..23). Returns flat list of { day, hour,
+// count } for easy <Recharts ScatterChart> rendering — Recharts doesn't
+// have a true heatmap component but ScatterChart with sized dots reads
+// the same way at this density.
+export interface HeatmapCell { day: number; dayLabel: string; hour: number; count: number; }
+
+export async function getActivityHeatmap(weeks = 12): Promise<HeatmapCell[]> {
+  const start = new Date(Date.now() - weeks * 7 * 24 * 3600 * 1000);
+  const rows = await prisma.run.findMany({
+    where: { serverReceivedAt: { gte: start } },
+    select: { serverReceivedAt: true },
+  });
+  const counts = new Map<string, number>();   // key = `${day}:${hour}`
+  for (const r of rows) {
+    const t = new Date(r.serverReceivedAt);
+    const key = `${t.getDay()}:${t.getHours()}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const out: HeatmapCell[] = [];
+  for (let day = 0; day < 7; day++) {
+    for (let hour = 0; hour < 24; hour++) {
+      out.push({
+        day,
+        dayLabel: dayLabels[day],
+        hour,
+        count: counts.get(`${day}:${hour}`) ?? 0,
+      });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Recent runs (admin view — includes hidden + banned-user runs)
+// ---------------------------------------------------------------------------
+export interface AdminRunRow {
+  id: string;
+  game: string;
+  challengeName: string;
+  score: number | null;
+  completionTimeFrames: number | null;
+  serverReceivedAt: Date;
+  hiddenAt: Date | null;
+  hiddenReason: string | null;
+  user: { id: string; name: string; bannedAt: Date | null };
+}
+
+export async function listAdminRuns(opts: {
+  take?: number;
+  skip?: number;
+  game?: string;
+  userId?: string;
+  hidden?: 'all' | 'visible' | 'hidden';
+} = {}): Promise<AdminRunRow[]> {
+  const take = Math.min(opts.take ?? 50, 200);
+  const skip = opts.skip ?? 0;
+  const where: Record<string, unknown> = {};
+  if (opts.game)   where.game = opts.game;
+  if (opts.userId) where.userId = opts.userId;
+  if (opts.hidden === 'visible') where.hiddenAt = null;
+  if (opts.hidden === 'hidden')  where.hiddenAt = { not: null };
+
+  const rows = await prisma.run.findMany({
+    where,
+    orderBy: { serverReceivedAt: 'desc' },
+    take,
+    skip,
+    select: {
+      id: true,
+      game: true,
+      challengeName: true,
+      score: true,
+      completionTimeFrames: true,
+      serverReceivedAt: true,
+      hiddenAt: true,
+      hiddenReason: true,
+      user: { select: { id: true, name: true, bannedAt: true } },
+    },
+  });
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// User list (admin view)
+// ---------------------------------------------------------------------------
+export interface AdminUserRow {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: Date;
+  bannedAt: Date | null;
+  totalRuns: number;
+  lastRunAt: Date | null;
+}
+
+export async function listAdminUsers(): Promise<AdminUserRow[]> {
+  const users = await prisma.user.findMany({
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      createdAt: true,
+      bannedAt: true,
+      runs: {
+        select: { serverReceivedAt: true },
+        orderBy: { serverReceivedAt: 'desc' },
+        take: 1,
+      },
+      _count: { select: { runs: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+  return users.map((u) => ({
+    id: u.id,
+    name: u.name,
+    email: u.email,
+    createdAt: u.createdAt,
+    bannedAt: u.bannedAt,
+    totalRuns: u._count.runs,
+    lastRunAt: u.runs[0]?.serverReceivedAt ?? null,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Per-challenge stats (admin view of every challenge that has at least
+// one run, plus a "days since last run" indicator for spotting stale).
+// ---------------------------------------------------------------------------
+export interface AdminChallengeStat {
+  game: string;
+  challengeName: string;
+  runs: number;
+  players: number;
+  fastestFrames: number | null;
+  fastestPlayer: string | null;
+  lastRunAt: Date | null;
+}
+
+export async function listAdminChallengeStats(): Promise<AdminChallengeStat[]> {
+  const groups = await prisma.run.groupBy({
+    by: ['game', 'challengeName'],
+    _count: { _all: true },
+    orderBy: [{ game: 'asc' }, { challengeName: 'asc' }],
+  });
+
+  return Promise.all(
+    groups.map(async (g) => {
+      const [players, fastest, latest] = await Promise.all([
+        prisma.run.groupBy({
+          by: ['userId'],
+          where: { game: g.game, challengeName: g.challengeName },
+        }),
+        prisma.run.findFirst({
+          where: {
+            game: g.game,
+            challengeName: g.challengeName,
+            hiddenAt: null,
+            user: { bannedAt: null },
+            completionTimeFrames: { not: null },
+          },
+          orderBy: { completionTimeFrames: 'asc' },
+          select: {
+            completionTimeFrames: true,
+            user: { select: { name: true } },
+          },
+        }),
+        prisma.run.findFirst({
+          where: { game: g.game, challengeName: g.challengeName },
+          orderBy: { serverReceivedAt: 'desc' },
+          select: { serverReceivedAt: true },
+        }),
+      ]);
+      return {
+        game: g.game,
+        challengeName: g.challengeName,
+        runs: g._count._all,
+        players: players.length,
+        fastestFrames: fastest?.completionTimeFrames ?? null,
+        fastestPlayer: fastest?.user.name ?? null,
+        lastRunAt: latest?.serverReceivedAt ?? null,
+      };
+    }),
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { timingSafeEqual } from 'node:crypto';
 import type { NextRequest } from 'next/server';
+import { notFound } from 'next/navigation';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/db';
 
@@ -51,6 +52,37 @@ export async function resolveTargetUserId(
     select: { id: true },
   });
   return user?.id ?? null;
+}
+
+// Admin session gate. Session-based equivalent of the bearer-token
+// admin path — used by the /admin pages and their server actions. The
+// token-based check stays for headless scripts; this one's for the
+// browser flow.
+//
+// Allowlist is hardcoded for now. When we have more than one admin we
+// can pivot to a User.role enum or an env-var-driven list, but adding
+// a second admin is rare enough that hardcoding is the lowest-friction
+// path.
+const ADMIN_EMAILS = new Set<string>([
+  'mdrimonakos@gmail.com',
+]);
+
+export function isAdminEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  return ADMIN_EMAILS.has(email.toLowerCase());
+}
+
+// Throws (via Next's notFound()) if the caller isn't a signed-in admin.
+// notFound() pretends the page doesn't exist rather than 401-ing — keeps
+// the admin URL invisible to anyone fishing for it.
+export async function requireAdmin(): Promise<{ userId: string; email: string }> {
+  const session = await auth();
+  const email = session?.user?.email ?? null;
+  const userId = session?.user?.id ?? null;
+  if (!userId || !isAdminEmail(email)) {
+    notFound();
+  }
+  return { userId, email: email as string };
 }
 
 export function verifyAdminToken(headerValue: string | null | undefined): boolean {


### PR DESCRIPTION
## Summary
Full moderator section at \`flawlessnes.com/admin\`. Allowlist-gated to \`mdrimonakos@gmail.com\` for now.

## Pages
| URL | What |
|---|---|
| \`/admin\` | KPI cards + 5 charts: 24h hourly submissions, 30d daily submissions, day×hour activity heatmap (12 weeks), top-10 challenges by runs (bar), top-10 players by runs (bar) |
| \`/admin/runs\` | Paginated runs table. Filter by hidden / game / userId. Per-row Hide / Restore / Delete |
| \`/admin/users\` | Every user with run count + last activity + ban toggle |
| \`/admin/users/[userId]\` | Per-user drill: identity, runs, inline run-row moderation |
| \`/admin/challenges\` | Read-only per-challenge stats: runs / players / fastest / held-by / days-since-last-run (30d-stale highlighted yellow) |

## Auth
- \`ADMIN_EMAILS\` allowlist hardcoded in \`lib/auth.ts\` (\`mdrimonakos@gmail.com\`)
- \`requireAdmin()\` helper — calls \`notFound()\` on a miss so the section is invisible to anyone fishing
- Layout AND each server action re-check (layout gating alone is bypassable via direct action POST)

## Mutations
Server actions in \`src/app/admin/actions.ts\`:
- \`hideRunAction\` / \`unhideRunAction\` / \`deleteRunAction\`
- \`banUserAction\` / \`unbanUserAction\` (with self-ban guard so an admin can't lock themselves out)

## Charts
Recharts. ~116kB JS on \`/admin\` only — the public site is unaffected. NES palette pinned across all chart elements (red bars, gray gridlines, dark tooltips). Heatmap rendered as a sized-dot ScatterChart since Recharts doesn't have a true heatmap.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 53/53 passing
- [x] \`npm run build\` — all admin routes registered
- [ ] Sign in as \`mdrimonakos@gmail.com\` → \`/admin\` loads, dashboard renders, every drill link works
- [ ] Sign in as any other user → \`/admin\` returns 404 (notFound from requireAdmin)
- [ ] Hide a run → it disappears from public \`/leaderboards/c/...\`
- [ ] Ban a user → their runs vanish from public boards (existing query filters \`bannedAt: null\`)
- [ ] Self-ban attempt → server action throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)