### PR TITLE
feat(admin): dynamic admin grant + audit log + site banner

### DIFF
--- a/prisma/migrations/20260502000000_admin_role_audit_settings/migration.sql
+++ b/prisma/migrations/20260502000000_admin_role_audit_settings/migration.sql
@@ -1,0 +1,43 @@
+-- Admin role: DB column + bootstrap allowlist together replace the
+-- previous hardcoded-only check. Defaulting false so existing rows are
+-- non-admin until explicitly granted.
+ALTER TABLE "User" ADD COLUMN "isAdmin" BOOLEAN NOT NULL DEFAULT false;
+
+-- Audit log for admin actions. Free-form action / targetType strings so
+-- adding new action kinds doesn't require a migration. metadata is JSONB
+-- for the same reason — different actions store different shapes.
+CREATE TABLE "AuditLog" (
+    "id"            TEXT NOT NULL,
+    "actorUserId"   TEXT NOT NULL,
+    "action"        TEXT NOT NULL,
+    "targetType"    TEXT,
+    "targetId"      TEXT,
+    "metadata"      JSONB,
+    "createdAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "AuditLog_createdAt_idx"   ON "AuditLog"("createdAt");
+CREATE INDEX "AuditLog_actorUserId_idx" ON "AuditLog"("actorUserId");
+
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_actorUserId_fkey"
+    FOREIGN KEY ("actorUserId") REFERENCES "User"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Singleton site settings (banner text + future flags). Hardcoded id=1
+-- so the table only ever holds one row.
+CREATE TABLE "SiteSetting" (
+    "id"               INTEGER NOT NULL DEFAULT 1,
+    "bannerText"       TEXT,
+    "bannerLevel"      TEXT,
+    "bannerUpdatedAt"  TIMESTAMP(3),
+    "bannerUpdatedBy"  TEXT,
+    "updatedAt"        TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SiteSetting_pkey" PRIMARY KEY ("id")
+);
+
+-- Seed the singleton row so getSiteSetting() always finds something to
+-- return rather than null-guarding everywhere.
+INSERT INTO "SiteSetting" ("id", "updatedAt") VALUES (1, CURRENT_TIMESTAMP);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,10 @@ model User {
   // Soft-ban. Banned users' runs are hidden from public leaderboards even
   // if individual runs aren't marked hiddenAt.
   bannedAt   DateTime?
+  // DB-backed admin role. requireAdmin() also honours a hardcoded
+  // bootstrap allowlist so the very first admin can never be locked
+  // out by a botched isAdmin write.
+  isAdmin    Boolean   @default(false)
 
   // NextAuth fields — emailVerified is required by the adapter; we leave
   // it nullable since Google OAuth doesn't reliably populate it.
@@ -49,11 +53,48 @@ model User {
   // a much larger refactor than carrying one extra column.
   image         String?
 
-  runs     Run[]
-  accounts Account[]
-  sessions Session[]
+  runs       Run[]
+  accounts   Account[]
+  sessions   Session[]
+  auditLogs  AuditLog[]   @relation("AuditActor")
 
   @@index([createdAt])
+}
+
+// ---------------------------------------------------------------------------
+// Admin moderation paper-trail. Every admin server action writes a row.
+// `targetType` is a free-form string (`run` | `user` | `setting` etc.);
+// `targetId` and `metadata` are optional so we don't have to migrate the
+// table every time a new action shape appears.
+// ---------------------------------------------------------------------------
+model AuditLog {
+  id          String   @id @default(cuid())
+  actorUserId String
+  actor       User     @relation("AuditActor", fields: [actorUserId], references: [id])
+
+  action      String
+  targetType  String?
+  targetId    String?
+  metadata    Json?
+
+  createdAt   DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([actorUserId])
+}
+
+// ---------------------------------------------------------------------------
+// Site-wide singleton settings (banner text, future flags). Keyed on
+// id=1 — there's exactly one row, ever. Nullable fields so the page
+// can default-skip rendering when nothing is set.
+// ---------------------------------------------------------------------------
+model SiteSetting {
+  id              Int       @id @default(1)
+  bannerText      String?
+  bannerLevel     String?   // info | warn | success — drives palette
+  bannerUpdatedAt DateTime?
+  bannerUpdatedBy String?
+  updatedAt       DateTime  @updatedAt
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,29 +1,64 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/db';
-import { requireAdmin } from '@/lib/auth';
+import { requireAdmin, isBootstrapAdminEmail } from '@/lib/auth';
 
 // Server actions used by the admin pages. Each one re-checks
 // requireAdmin() — even though the layout already gated rendering,
 // server actions are individually-callable POST endpoints that bypass
 // the layout, so we must NOT trust the layout-level gate alone.
+//
+// Every mutation also writes an AuditLog row via writeAudit() so we
+// have a tamper-evident moderation paper-trail.
 
+async function writeAudit(
+  actorUserId: string,
+  action: string,
+  targetType: string | null,
+  targetId: string | null,
+  metadata?: Prisma.InputJsonValue | null,
+) {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        actorUserId,
+        action,
+        targetType,
+        targetId,
+        // Prisma's typed-null sentinel for "the column is JSON SQL NULL".
+        // Passing literal null wouldn't typecheck against InputJsonValue.
+        metadata: metadata ?? Prisma.JsonNull,
+      },
+    });
+  } catch (err) {
+    // Audit write failure shouldn't break the moderation action itself —
+    // the action already mutated. Log loudly so we notice.
+    console.error('[audit] write failed for', action, '— continuing:', err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run moderation
+// ---------------------------------------------------------------------------
 export async function hideRunAction(runId: string, reason: string | null) {
-  await requireAdmin();
+  const me = await requireAdmin();
   await prisma.run.update({
     where: { id: runId },
     data: { hiddenAt: new Date(), hiddenReason: reason || null },
   });
+  await writeAudit(me.userId, 'hide_run', 'run', runId, { reason: reason || null });
   revalidatePath('/admin/runs');
 }
 
 export async function unhideRunAction(runId: string) {
-  await requireAdmin();
+  const me = await requireAdmin();
   await prisma.run.update({
     where: { id: runId },
     data: { hiddenAt: null, hiddenReason: null },
   });
+  await writeAudit(me.userId, 'unhide_run', 'run', runId, null);
   revalidatePath('/admin/runs');
 }
 
@@ -31,16 +66,23 @@ export async function unhideRunAction(runId: string) {
 // the row goes away completely. Most cases should use hide instead;
 // reserve delete for spam / test data / GDPR-style requests.
 export async function deleteRunAction(runId: string) {
-  await requireAdmin();
+  const me = await requireAdmin();
+  // Snapshot useful metadata before delete so the audit row tells the
+  // story even after the Run row is gone.
+  const snap = await prisma.run.findUnique({
+    where: { id: runId },
+    select: { game: true, challengeName: true, userId: true },
+  });
   await prisma.run.delete({ where: { id: runId } });
+  await writeAudit(me.userId, 'delete_run', 'run', runId, snap as unknown as Prisma.InputJsonValue);
   revalidatePath('/admin/runs');
 }
 
+// ---------------------------------------------------------------------------
+// User moderation
+// ---------------------------------------------------------------------------
 export async function banUserAction(userId: string) {
   const me = await requireAdmin();
-  // Belt-and-suspenders: never let an admin ban themselves and lock
-  // out the admin section. Hardcoded allowlist would let them back in,
-  // but a permanent self-mistake is annoying. Just no.
   if (userId === me.userId) {
     throw new Error("Can't ban yourself.");
   }
@@ -48,16 +90,102 @@ export async function banUserAction(userId: string) {
     where: { id: userId },
     data: { bannedAt: new Date() },
   });
+  await writeAudit(me.userId, 'ban_user', 'user', userId, null);
   revalidatePath('/admin/users');
   revalidatePath('/admin');
 }
 
 export async function unbanUserAction(userId: string) {
-  await requireAdmin();
+  const me = await requireAdmin();
   await prisma.user.update({
     where: { id: userId },
     data: { bannedAt: null },
   });
+  await writeAudit(me.userId, 'unban_user', 'user', userId, null);
   revalidatePath('/admin/users');
   revalidatePath('/admin');
+}
+
+// ---------------------------------------------------------------------------
+// Admin role grants
+// ---------------------------------------------------------------------------
+export async function grantAdminAction(userId: string) {
+  const me = await requireAdmin();
+  await prisma.user.update({
+    where: { id: userId },
+    data: { isAdmin: true },
+  });
+  await writeAudit(me.userId, 'grant_admin', 'user', userId, null);
+  revalidatePath('/admin/users');
+  revalidatePath(`/admin/users/${userId}`);
+}
+
+export async function revokeAdminAction(userId: string) {
+  const me = await requireAdmin();
+  // Self-revoke guard: an admin demoting themselves is a footgun. The
+  // bootstrap allowlist would let them recover, but for any non-bootstrap
+  // admin a self-revoke would lock them out permanently.
+  if (userId === me.userId && !isBootstrapAdminEmail(me.email)) {
+    throw new Error("Can't revoke your own admin role.");
+  }
+  await prisma.user.update({
+    where: { id: userId },
+    data: { isAdmin: false },
+  });
+  await writeAudit(me.userId, 'revoke_admin', 'user', userId, null);
+  revalidatePath('/admin/users');
+  revalidatePath(`/admin/users/${userId}`);
+}
+
+// ---------------------------------------------------------------------------
+// Site settings (banner)
+// ---------------------------------------------------------------------------
+const VALID_BANNER_LEVELS = new Set(['info', 'warn', 'success']);
+
+export async function setBannerAction(text: string, level: string) {
+  const me = await requireAdmin();
+  const trimmed = text.trim();
+  if (!trimmed) {
+    throw new Error('Banner text cannot be empty — use Clear instead.');
+  }
+  const lvl = VALID_BANNER_LEVELS.has(level) ? level : 'info';
+  await prisma.siteSetting.upsert({
+    where: { id: 1 },
+    update: {
+      bannerText:      trimmed,
+      bannerLevel:     lvl,
+      bannerUpdatedAt: new Date(),
+      bannerUpdatedBy: me.userId,
+    },
+    create: {
+      id: 1,
+      bannerText:      trimmed,
+      bannerLevel:     lvl,
+      bannerUpdatedAt: new Date(),
+      bannerUpdatedBy: me.userId,
+    },
+  });
+  await writeAudit(me.userId, 'set_banner', 'setting', 'banner', { text: trimmed, level: lvl });
+  // Banner shows on every public page so revalidate broadly.
+  revalidatePath('/', 'layout');
+}
+
+export async function clearBannerAction() {
+  const me = await requireAdmin();
+  await prisma.siteSetting.upsert({
+    where: { id: 1 },
+    update: {
+      bannerText:      null,
+      bannerLevel:     null,
+      bannerUpdatedAt: new Date(),
+      bannerUpdatedBy: me.userId,
+    },
+    create: {
+      id: 1,
+      bannerUpdatedAt: new Date(),
+      bannerUpdatedBy: me.userId,
+    },
+  });
+  await writeAudit(me.userId, 'clear_banner', 'setting', 'banner', null);
+  revalidatePath('/', 'layout');
 }

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -1,0 +1,172 @@
+import Link from 'next/link';
+import { listAuditLog } from '@/lib/admin';
+import { userProfileHref, challengeHref } from '@/lib/leaderboard';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  searchParams: Promise<{ actor?: string; action?: string; page?: string }>;
+}
+
+const PAGE_SIZE = 100;
+
+const ACTIONS = [
+  'hide_run', 'unhide_run', 'delete_run',
+  'ban_user', 'unban_user',
+  'grant_admin', 'revoke_admin',
+  'set_banner', 'clear_banner',
+] as const;
+
+export default async function AdminAuditPage({ searchParams }: PageProps) {
+  const sp = await searchParams;
+  const actorUserId = sp.actor?.trim() || undefined;
+  const action      = sp.action?.trim() || undefined;
+  const page        = Math.max(0, parseInt(sp.page ?? '0', 10) || 0);
+
+  const rows = await listAuditLog({
+    take: PAGE_SIZE,
+    skip: page * PAGE_SIZE,
+    actorUserId,
+    action,
+  });
+
+  return (
+    <div className="space-y-4">
+      <header>
+        <h1 className="font-display text-2xl font-bold text-white">Audit log</h1>
+        <p className="text-sm text-slate-400 mt-1">
+          Every admin mutation is recorded here. Newest first. Filter by actor or
+          action; metadata column is the JSON the action stored.
+        </p>
+      </header>
+
+      <form className="flex flex-wrap items-center gap-2 text-xs">
+        <input
+          type="text"
+          name="actor"
+          placeholder="actor user id"
+          defaultValue={actorUserId ?? ''}
+          className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200 w-64"
+        />
+        <select
+          name="action"
+          defaultValue={action ?? ''}
+          className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200"
+        >
+          <option value="">all actions</option>
+          {ACTIONS.map((a) => <option key={a} value={a}>{a}</option>)}
+        </select>
+        <button
+          type="submit"
+          className="rounded-md bg-indigo-500 px-3 py-1 text-white font-medium hover:bg-indigo-600"
+        >
+          Filter
+        </button>
+      </form>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-700 bg-slate-900">
+        <table className="w-full text-sm">
+          <thead className="text-left text-xs uppercase text-slate-500 border-b border-slate-700">
+            <tr>
+              <th className="px-3 py-2">When</th>
+              <th className="px-3 py-2">Actor</th>
+              <th className="px-3 py-2">Action</th>
+              <th className="px-3 py-2">Target</th>
+              <th className="px-3 py-2">Metadata</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-t border-slate-800">
+                <td className="px-3 py-2 text-xs text-slate-500 whitespace-nowrap">
+                  {new Date(r.createdAt).toLocaleString(undefined, {
+                    month: 'short', day: 'numeric',
+                    hour: '2-digit', minute: '2-digit', second: '2-digit',
+                  })}
+                </td>
+                <td className="px-3 py-2">
+                  <Link
+                    href={userProfileHref(r.actorUserId)}
+                    className="text-slate-200 hover:text-indigo-300"
+                  >
+                    {r.actorName}
+                  </Link>
+                </td>
+                <td className="px-3 py-2">
+                  <ActionBadge action={r.action} />
+                </td>
+                <td className="px-3 py-2 text-xs">
+                  <TargetCell type={r.targetType} id={r.targetId} metadata={r.metadata} />
+                </td>
+                <td className="px-3 py-2 text-xs text-slate-500 font-mono max-w-md truncate" title={r.metadata ? JSON.stringify(r.metadata) : ''}>
+                  {r.metadata ? JSON.stringify(r.metadata) : <span className="text-slate-700">—</span>}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-3 py-8 text-center text-slate-500">
+                  No audit entries match these filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <Pagination page={page} hasMore={rows.length === PAGE_SIZE} actor={actorUserId} action={action} />
+    </div>
+  );
+}
+
+function ActionBadge({ action }: { action: string }) {
+  const palette =
+    action.startsWith('grant_') || action.startsWith('unhide') || action.startsWith('unban') ? 'bg-emerald-500/20 text-emerald-300' :
+    action.startsWith('delete') || action.startsWith('ban_')   || action.startsWith('revoke') ? 'bg-red-500/20 text-red-300'         :
+    action.startsWith('hide')   || action.startsWith('clear_') ? 'bg-amber-500/20 text-amber-300'                                    :
+                                                                  'bg-indigo-500/20 text-indigo-300';
+  return <span className={`rounded-md px-1.5 py-0.5 font-mono text-xs ${palette}`}>{action}</span>;
+}
+
+function TargetCell({ type, id, metadata }: { type: string | null; id: string | null; metadata: unknown }) {
+  if (!type) return <span className="text-slate-700">—</span>;
+  if (type === 'user' && id) {
+    return (
+      <Link href={`/admin/users/${id}`} className="text-indigo-300 hover:text-indigo-200">
+        user · <span className="font-mono">{id.slice(0, 8)}…</span>
+      </Link>
+    );
+  }
+  if (type === 'run' && id) {
+    // After delete the Run is gone; metadata snapshot has game / challenge.
+    const meta = metadata as { game?: string; challengeName?: string } | null;
+    if (meta?.game && meta?.challengeName) {
+      return (
+        <Link href={challengeHref(meta.game, meta.challengeName)} className="text-indigo-300 hover:text-indigo-200">
+          run · {meta.game} — {meta.challengeName}
+        </Link>
+      );
+    }
+    return <span className="font-mono text-slate-400">run · {id.slice(0, 8)}…</span>;
+  }
+  return <span className="font-mono text-slate-400">{type}{id ? ` · ${id.slice(0, 16)}` : ''}</span>;
+}
+
+function Pagination({ page, hasMore, actor, action }: { page: number; hasMore: boolean; actor?: string; action?: string }) {
+  const params = (n: number) => {
+    const sp = new URLSearchParams();
+    if (actor)  sp.set('actor', actor);
+    if (action) sp.set('action', action);
+    if (n > 0)  sp.set('page', String(n));
+    return sp.toString() ? `?${sp.toString()}` : '';
+  };
+  return (
+    <div className="flex items-center justify-between text-xs text-slate-500">
+      <span>Page {page + 1}</span>
+      <div className="space-x-2">
+        {page > 0 && <Link href={`/admin/audit${params(page - 1)}`} className="hover:text-slate-200">← Prev</Link>}
+        {hasMore && <Link href={`/admin/audit${params(page + 1)}`} className="hover:text-slate-200">Next →</Link>}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -17,6 +17,8 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           <AdminNavLink href="/admin/runs">      Runs        </AdminNavLink>
           <AdminNavLink href="/admin/users">     Users       </AdminNavLink>
           <AdminNavLink href="/admin/challenges">Challenges  </AdminNavLink>
+          <AdminNavLink href="/admin/audit">     Audit log   </AdminNavLink>
+          <AdminNavLink href="/admin/settings">  Settings    </AdminNavLink>
         </nav>
         <div className="mt-6 text-xs text-slate-600">
           Signed in as admin. Public links above the page header still

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,0 +1,103 @@
+import { getSiteBanner } from '@/lib/admin';
+import { setBannerAction, clearBannerAction } from '@/app/admin/actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminSettingsPage() {
+  const banner = await getSiteBanner();
+
+  return (
+    <div className="space-y-8 max-w-2xl">
+      <header>
+        <h1 className="font-display text-2xl font-bold text-white">Settings</h1>
+        <p className="text-sm text-slate-400 mt-1">
+          Site-wide config that takes effect for every visitor as soon as you save.
+        </p>
+      </header>
+
+      <section className="rounded-lg border border-slate-700 bg-slate-900 p-5 space-y-3">
+        <div>
+          <h2 className="font-display text-lg font-semibold text-white">Site banner</h2>
+          <p className="text-xs text-slate-500 mt-1">
+            Renders at the top of every page. Pick a level to color it (info / warn / success).
+            Leave blank and Clear to remove. Updates propagate immediately.
+          </p>
+        </div>
+
+        {banner.text && (
+          <div className="rounded-md border border-slate-700 bg-slate-925 p-3 text-xs text-slate-400">
+            <div className="text-slate-500 uppercase tracking-wider mb-1">currently showing</div>
+            <div className="text-slate-200 mb-1">{banner.text}</div>
+            <div>
+              level: <span className="text-slate-300">{banner.level}</span>
+              {banner.updatedAt && (
+                <> · set {new Date(banner.updatedAt).toLocaleString()}</>
+              )}
+            </div>
+          </div>
+        )}
+
+        <form
+          action={async (data) => {
+            'use server';
+            const text  = (data.get('text')  as string) || '';
+            const level = (data.get('level') as string) || 'info';
+            await setBannerAction(text, level);
+          }}
+          className="space-y-3"
+        >
+          <div>
+            <label htmlFor="banner-text" className="block text-xs uppercase text-slate-500 mb-1">
+              Banner text
+            </label>
+            <textarea
+              id="banner-text"
+              name="text"
+              rows={2}
+              defaultValue={banner.text ?? ''}
+              maxLength={300}
+              className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none"
+              placeholder="e.g. Servers down for maintenance Friday 8pm UTC"
+            />
+          </div>
+          <div>
+            <label htmlFor="banner-level" className="block text-xs uppercase text-slate-500 mb-1">
+              Level
+            </label>
+            <select
+              id="banner-level"
+              name="level"
+              defaultValue={banner.level ?? 'info'}
+              className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none"
+            >
+              <option value="info">info (indigo)</option>
+              <option value="warn">warn (amber)</option>
+              <option value="success">success (emerald)</option>
+            </select>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="rounded-md bg-indigo-500 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-600"
+            >
+              Save banner
+            </button>
+          </div>
+        </form>
+
+        {banner.text && (
+          <form
+            action={async () => { 'use server'; await clearBannerAction(); }}
+          >
+            <button
+              type="submit"
+              className="rounded-md bg-red-500/20 px-3 py-1.5 text-xs font-medium text-red-300 hover:bg-red-500/30"
+            >
+              Clear banner
+            </button>
+          </form>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,7 +1,12 @@
 import Link from 'next/link';
 import { listAdminUsers } from '@/lib/admin';
 import { userProfileHref } from '@/lib/leaderboard';
-import { banUserAction, unbanUserAction } from '@/app/admin/actions';
+import {
+  banUserAction,
+  unbanUserAction,
+  grantAdminAction,
+  revokeAdminAction,
+} from '@/app/admin/actions';
 
 export const dynamic = 'force-dynamic';
 
@@ -64,8 +69,24 @@ export default async function AdminUsersPage() {
                   {u.bannedAt
                     ? <span className="text-red-400">banned</span>
                     : <span className="text-emerald-300">active</span>}
+                  {u.isAdmin && <span className="ml-2 text-indigo-300">★ admin</span>}
                 </td>
                 <td className="px-3 py-2 text-right whitespace-nowrap">
+                  {u.isAdmin ? (
+                    <form
+                      action={async () => { 'use server'; await revokeAdminAction(u.id); }}
+                      className="inline mr-1"
+                    >
+                      <ActionButton type="submit" variant="warn">Revoke admin</ActionButton>
+                    </form>
+                  ) : (
+                    <form
+                      action={async () => { 'use server'; await grantAdminAction(u.id); }}
+                      className="inline mr-1"
+                    >
+                      <ActionButton type="submit" variant="ok">Make admin</ActionButton>
+                    </form>
+                  )}
                   {u.bannedAt ? (
                     <form
                       action={async () => { 'use server'; await unbanUserAction(u.id); }}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { HeaderSearch } from '@/components/HeaderSearch';
 import { HeaderUserMenu } from '@/components/HeaderUserMenu';
+import { getSiteBanner } from '@/lib/admin';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -9,7 +10,8 @@ export const metadata: Metadata = {
   description: 'Community leaderboards for FlawlessNES — retro gaming challenges with verified completions.',
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const banner = await getSiteBanner();
   return (
     <html lang="en" className="h-full">
       <head>
@@ -21,6 +23,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body className="h-full bg-slate-925 text-slate-200 font-sans antialiased">
+        {banner.text && <SiteBanner text={banner.text} level={banner.level} />}
         <header className="border-b border-slate-700 bg-slate-900/80 backdrop-blur sticky top-0 z-10">
           <div className="max-w-5xl mx-auto px-4 py-4 flex items-center gap-4">
             <Link href="/" className="font-display text-xl font-bold text-white shrink-0">
@@ -42,5 +45,22 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         </footer>
       </body>
     </html>
+  );
+}
+
+// Site-wide announcement bar. Server-rendered from SiteSetting so the
+// admin's edit takes effect on the next request without a deploy.
+// Three levels drive the palette; defaults to info if level is unknown.
+function SiteBanner({ text, level }: { text: string; level: string | null }) {
+  const palette =
+    level === 'warn'    ? 'bg-amber-500/20   text-amber-100  border-amber-400/40'  :
+    level === 'success' ? 'bg-emerald-500/20 text-emerald-100 border-emerald-400/40' :
+                          'bg-indigo-500/20  text-indigo-100  border-indigo-400/40';
+  return (
+    <div className={`border-b ${palette}`}>
+      <div className="max-w-5xl mx-auto px-4 py-2 text-sm text-center">
+        {text}
+      </div>
+    </div>
   );
 }

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -276,6 +276,7 @@ export interface AdminUserRow {
   email: string;
   createdAt: Date;
   bannedAt: Date | null;
+  isAdmin: boolean;
   totalRuns: number;
   lastRunAt: Date | null;
 }
@@ -288,6 +289,7 @@ export async function listAdminUsers(): Promise<AdminUserRow[]> {
       email: true,
       createdAt: true,
       bannedAt: true,
+      isAdmin: true,
       runs: {
         select: { serverReceivedAt: true },
         orderBy: { serverReceivedAt: 'desc' },
@@ -303,9 +305,85 @@ export async function listAdminUsers(): Promise<AdminUserRow[]> {
     email: u.email,
     createdAt: u.createdAt,
     bannedAt: u.bannedAt,
+    isAdmin: u.isAdmin,
     totalRuns: u._count.runs,
     lastRunAt: u.runs[0]?.serverReceivedAt ?? null,
   }));
+}
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+export interface AuditRow {
+  id: string;
+  createdAt: Date;
+  actorUserId: string;
+  actorName: string;
+  action: string;
+  targetType: string | null;
+  targetId: string | null;
+  metadata: unknown;
+}
+
+export async function listAuditLog(opts: {
+  take?: number;
+  skip?: number;
+  actorUserId?: string;
+  action?: string;
+} = {}): Promise<AuditRow[]> {
+  const take = Math.min(opts.take ?? 100, 500);
+  const skip = opts.skip ?? 0;
+  const where: Record<string, unknown> = {};
+  if (opts.actorUserId) where.actorUserId = opts.actorUserId;
+  if (opts.action)      where.action      = opts.action;
+
+  const rows = await prisma.auditLog.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take,
+    skip,
+    include: {
+      actor: { select: { name: true } },
+    },
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    createdAt: r.createdAt,
+    actorUserId: r.actorUserId,
+    actorName: r.actor?.name ?? '(deleted user)',
+    action: r.action,
+    targetType: r.targetType,
+    targetId: r.targetId,
+    metadata: r.metadata,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Site setting (singleton)
+// ---------------------------------------------------------------------------
+export interface SiteBanner {
+  text: string | null;
+  level: string | null;
+  updatedAt: Date | null;
+  updatedBy: string | null;
+}
+
+export async function getSiteBanner(): Promise<SiteBanner> {
+  // Called from the root layout, which Next sometimes pre-renders for
+  // static pages (e.g. /_not-found). Build environments may not have
+  // DATABASE_URL set; rather than crashing the prerender, we degrade
+  // to "no banner" and the layout renders normally without the bar.
+  try {
+    const row = await prisma.siteSetting.findUnique({ where: { id: 1 } });
+    return {
+      text:      row?.bannerText      ?? null,
+      level:     row?.bannerLevel     ?? null,
+      updatedAt: row?.bannerUpdatedAt ?? null,
+      updatedBy: row?.bannerUpdatedBy ?? null,
+    };
+  } catch {
+    return { text: null, level: null, updatedAt: null, updatedBy: null };
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -55,21 +55,23 @@ export async function resolveTargetUserId(
 }
 
 // Admin session gate. Session-based equivalent of the bearer-token
-// admin path — used by the /admin pages and their server actions. The
-// token-based check stays for headless scripts; this one's for the
-// browser flow.
+// admin path — used by the /admin pages and their server actions.
 //
-// Allowlist is hardcoded for now. When we have more than one admin we
-// can pivot to a User.role enum or an env-var-driven list, but adding
-// a second admin is rare enough that hardcoding is the lowest-friction
-// path.
-const ADMIN_EMAILS = new Set<string>([
+// Two ways in:
+//   1. User.isAdmin == true (DB-backed; granted/revoked via /admin/users)
+//   2. Bootstrap allowlist (hardcoded emails)
+//
+// The bootstrap allowlist exists so the very first admin can never be
+// locked out — even if a botched DB write demotes everyone, the
+// hardcoded address still authenticates. Treat ADMIN_BOOTSTRAP_EMAILS
+// as "owners who can always recover the system".
+const ADMIN_BOOTSTRAP_EMAILS = new Set<string>([
   'mdrimonakos@gmail.com',
 ]);
 
-export function isAdminEmail(email: string | null | undefined): boolean {
+export function isBootstrapAdminEmail(email: string | null | undefined): boolean {
   if (!email) return false;
-  return ADMIN_EMAILS.has(email.toLowerCase());
+  return ADMIN_BOOTSTRAP_EMAILS.has(email.toLowerCase());
 }
 
 // Throws (via Next's notFound()) if the caller isn't a signed-in admin.
@@ -79,9 +81,20 @@ export async function requireAdmin(): Promise<{ userId: string; email: string }>
   const session = await auth();
   const email = session?.user?.email ?? null;
   const userId = session?.user?.id ?? null;
-  if (!userId || !isAdminEmail(email)) {
-    notFound();
+  if (!userId) notFound();
+
+  // Bootstrap path — short-circuit without a DB read.
+  if (isBootstrapAdminEmail(email)) {
+    return { userId, email: email as string };
   }
+
+  // DB-backed path. Single indexed lookup, cheap.
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { isAdmin: true, bannedAt: true },
+  });
+  if (!user || !user.isAdmin || user.bannedAt) notFound();
+
   return { userId, email: email as string };
 }
 


### PR DESCRIPTION
## Summary
Three new admin capabilities, one migration.

| Capability | Where | What |
|---|---|---|
| Dynamic admin grant | \`/admin/users\` | Make / Revoke admin button per user. \`requireAdmin()\` now checks \`User.isAdmin\` OR the bootstrap allowlist (so the first admin can never be locked out). Self-revoke guard for non-bootstrap admins. |
| Audit log | \`/admin/audit\` | Every admin server action writes an \`AuditLog\` row. Page renders newest-first, filterable by actor / action, with color-coded badges and links into the affected user / challenge. Delete-run snapshots the (game, challenge, userId) before deleting so the audit row stays informative after the Run is gone. |
| Site banner | \`/admin/settings\` | Set/clear a site-wide announcement. Three levels (info / warn / success) drive the palette. Layout server-renders at top of every page; \`revalidatePath('/', 'layout')\` propagates instantly. |

## Schema
Migration \`20260502000000_admin_role_audit_settings\`:
- \`User.isAdmin BOOLEAN DEFAULT false\`
- New \`AuditLog\` table (id, actorUserId, action, targetType, targetId, metadata JSONB, createdAt + indexes)
- New \`SiteSetting\` singleton (id=1) seeded by the migration so \`getSiteBanner\` always finds a row

## Build resilience
\`getSiteBanner()\` is now called from the root layout, which Next prerenders for static pages (\`/_not-found\`). Wrapped in try/catch so a build environment without \`DATABASE_URL\` degrades to "no banner" rather than crashing the prerender — same fail-graceful pattern the manifest fetcher uses.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 53/53 passing
- [x] \`npm run build\` — green, no prerender crash
- [ ] After deploy + migration applied:
  - [ ] /admin/users shows admin badge on me, no admin badge on others
  - [ ] Make-admin on a test user → audit log row appears, that user can now access /admin
  - [ ] Set a banner → bar appears across every page (with the right level color)
  - [ ] Clear banner → bar disappears
  - [ ] Hide / unhide / delete / ban / unban each write an audit row

🤖 Generated with [Claude Code](https://claude.com/claude-code)