### PR TITLE
feat(anti-cheat): per-challenge thresholds + /admin/pending review queue

### DIFF
--- a/prisma/migrations/20260503000000_run_pending_review/migration.sql
+++ b/prisma/migrations/20260503000000_run_pending_review/migration.sql
@@ -1,0 +1,9 @@
+-- Anti-cheat review queue. Runs that come in suspiciously fast (below
+-- a per-challenge flagBelowFrames threshold in the manifest) are
+-- inserted with pendingReview=true and hidden from public leaderboards
+-- until an admin clears them in /admin/pending.
+
+ALTER TABLE "Run"
+  ADD COLUMN "pendingReview" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX "Run_pendingReview_idx" ON "Run"("pendingReview");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,6 +163,14 @@ model Run {
   hiddenAt             DateTime?
   hiddenReason         String?
 
+  // Anti-cheat review queue. The submit endpoint sets this to true when
+  // a run's completionTimeFrames falls below the challenge's
+  // flagBelowFrames threshold (suspiciously fast but not impossible).
+  // Pending runs are hidden from public leaderboards but still visible
+  // to the owner on /me with a "pending review" badge so they know it
+  // wasn't lost. An admin clears it via /admin/pending.
+  pendingReview        Boolean   @default(false)
+
   // Full original payload, kept for debugging and future replay support.
   rawPayload           Json
 
@@ -171,4 +179,5 @@ model Run {
   @@index([game, challengeName, score(sort: Desc), completionTimeFrames(sort: Asc)])
   @@index([userId, serverReceivedAt(sort: Desc)])
   @@index([hiddenAt])
+  @@index([pendingReview])
 }

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -79,6 +79,57 @@ export async function deleteRunAction(runId: string) {
 }
 
 // ---------------------------------------------------------------------------
+// Anti-cheat review queue. Runs come in pre-flagged when their
+// completionTimeFrames falls below the manifest's flagBelowFrames
+// threshold; an admin clears them via approve, or removes them via
+// reject. Both write to the audit log.
+// ---------------------------------------------------------------------------
+export async function approveRunAction(runId: string) {
+  const me = await requireAdmin();
+  const snap = await prisma.run.findUnique({
+    where: { id: runId },
+    select: { game: true, challengeName: true, userId: true, completionTimeFrames: true },
+  });
+  await prisma.run.update({
+    where: { id: runId },
+    data: { pendingReview: false },
+  });
+  await writeAudit(me.userId, 'approve_run', 'run', runId, snap as unknown as Prisma.InputJsonValue);
+  revalidatePath('/admin/pending');
+  revalidatePath('/admin');
+  if (snap) {
+    revalidatePath(`/leaderboards/c/${encodeURIComponent(snap.game)}/${encodeURIComponent(snap.challengeName)}`);
+  }
+}
+
+// Reject = hide. We don't hard-delete from the queue so the run row
+// stays available for forensic review later. Admin can hard-delete from
+// /admin/runs if needed.
+export async function rejectRunAction(runId: string, reason: string | null) {
+  const me = await requireAdmin();
+  const snap = await prisma.run.findUnique({
+    where: { id: runId },
+    select: { game: true, challengeName: true, userId: true, completionTimeFrames: true },
+  });
+  await prisma.run.update({
+    where: { id: runId },
+    data: {
+      // Clear pendingReview so it leaves the queue, and hide it so it
+      // never appears on the public leaderboard.
+      pendingReview: false,
+      hiddenAt: new Date(),
+      hiddenReason: reason || 'rejected from review queue',
+    },
+  });
+  await writeAudit(me.userId, 'reject_run', 'run', runId, {
+    reason: reason || null,
+    snapshot: snap,
+  } as unknown as Prisma.InputJsonValue);
+  revalidatePath('/admin/pending');
+  revalidatePath('/admin');
+}
+
+// ---------------------------------------------------------------------------
 // User moderation
 // ---------------------------------------------------------------------------
 export async function banUserAction(userId: string) {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -14,6 +14,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
         </h2>
         <nav className="space-y-1 text-sm">
           <AdminNavLink href="/admin">           Dashboard   </AdminNavLink>
+          <AdminNavLink href="/admin/pending">   Pending     </AdminNavLink>
           <AdminNavLink href="/admin/runs">      Runs        </AdminNavLink>
           <AdminNavLink href="/admin/users">     Users       </AdminNavLink>
           <AdminNavLink href="/admin/challenges">Challenges  </AdminNavLink>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -35,6 +35,16 @@ export default async function AdminDashboardPage() {
         </p>
       </header>
 
+      {kpis.pendingRuns > 0 && (
+        <Link
+          href="/admin/pending"
+          className="block rounded-lg border border-amber-400/40 bg-amber-500/10 px-4 py-3 text-amber-100 hover:bg-amber-500/20"
+        >
+          <span className="font-medium">{kpis.pendingRuns} run{kpis.pendingRuns === 1 ? '' : 's'} awaiting review</span>
+          <span className="ml-2 text-xs text-amber-300">→ open queue</span>
+        </Link>
+      )}
+
       <section className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         <Kpi label="users"        value={kpis.totalUsers}     sub={kpis.bannedUsers > 0 ? `${kpis.bannedUsers} banned` : undefined} />
         <Kpi label="runs"         value={kpis.totalRuns}      sub={kpis.hiddenRuns > 0 ? `${kpis.hiddenRuns} hidden` : undefined} />

--- a/src/app/admin/pending/page.tsx
+++ b/src/app/admin/pending/page.tsx
@@ -1,0 +1,118 @@
+import Link from 'next/link';
+import {
+  challengeHref,
+  formatFrames,
+  userProfileHref,
+} from '@/lib/leaderboard';
+import { listPendingRuns } from '@/lib/admin';
+import { approveRunAction, rejectRunAction } from '@/app/admin/actions';
+
+export const dynamic = 'force-dynamic';
+
+// Anti-cheat review queue. Runs land here when they came in below the
+// challenge's flagBelowFrames threshold (suspiciously fast but not
+// physically impossible). Approve clears the flag and they go live;
+// reject hides them with a reason and they leave the queue.
+export default async function AdminPendingPage() {
+  const rows = await listPendingRuns();
+
+  return (
+    <div className="space-y-4">
+      <header>
+        <h1 className="font-display text-2xl font-bold text-white">Pending review</h1>
+        <p className="text-sm text-slate-400 mt-1">
+          Runs flagged by the anti-cheat threshold. Approve to publish, or
+          reject to hide them. Runs are <span className="text-amber-300">not visible</span> on
+          public leaderboards while they sit here.
+        </p>
+      </header>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-700 bg-slate-900">
+        <table className="w-full text-sm">
+          <thead className="text-left text-xs uppercase text-slate-500 border-b border-slate-700">
+            <tr>
+              <th className="px-3 py-2">Submitted</th>
+              <th className="px-3 py-2">Player</th>
+              <th className="px-3 py-2">Game / Challenge</th>
+              <th className="px-3 py-2 text-right">Score</th>
+              <th className="px-3 py-2 text-right">Time</th>
+              <th className="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-t border-slate-800">
+                <td className="px-3 py-2 text-xs text-slate-500 whitespace-nowrap">
+                  {new Date(r.serverReceivedAt).toLocaleString(undefined, {
+                    month: 'short', day: 'numeric',
+                    hour: '2-digit', minute: '2-digit',
+                  })}
+                </td>
+                <td className="px-3 py-2">
+                  <Link
+                    href={userProfileHref(r.user.id)}
+                    className="text-slate-200 hover:text-indigo-300"
+                  >
+                    {r.user.name}
+                  </Link>
+                </td>
+                <td className="px-3 py-2">
+                  <Link
+                    href={challengeHref(r.game, r.challengeName)}
+                    className="text-slate-200 hover:text-indigo-300"
+                  >
+                    {r.game} — {r.challengeName}
+                  </Link>
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-slate-300">
+                  {r.score != null ? r.score.toLocaleString() : '—'}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-amber-300" title="below flagBelowFrames threshold">
+                  {formatFrames(r.completionTimeFrames)}
+                </td>
+                <td className="px-3 py-2 text-right whitespace-nowrap">
+                  <form
+                    action={async () => { 'use server'; await approveRunAction(r.id); }}
+                    className="inline mr-1"
+                  >
+                    <ActionButton type="submit" variant="ok">Approve</ActionButton>
+                  </form>
+                  <form
+                    action={async (data) => {
+                      'use server';
+                      await rejectRunAction(r.id, (data.get('reason') as string) || null);
+                    }}
+                    className="inline"
+                  >
+                    <input type="hidden" name="reason" value="suspicious time" />
+                    <ActionButton type="submit" variant="danger">Reject</ActionButton>
+                  </form>
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-3 py-8 text-center text-slate-500">
+                  Queue is empty — no runs awaiting review.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function ActionButton({ type, variant, children }: {
+  type?: 'button' | 'submit';
+  variant: 'ok' | 'warn' | 'danger';
+  children: React.ReactNode;
+}) {
+  const base = 'rounded-md px-2 py-1 text-xs font-medium';
+  const palette =
+    variant === 'ok'     ? 'bg-emerald-500/20 text-emerald-300 hover:bg-emerald-500/30' :
+    variant === 'warn'   ? 'bg-amber-500/20 text-amber-300 hover:bg-amber-500/30'       :
+                           'bg-red-500/20 text-red-300 hover:bg-red-500/30';
+  return <button type={type ?? 'button'} className={`${base} ${palette}`}>{children}</button>;
+}

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/db';
 import { verifySubmissionSecret } from '@/lib/auth';
 import { isBetterRun, getChallengeLeaderboard, challengeHref } from '@/lib/leaderboard';
 import { notifyDiscordTopPlacement } from '@/lib/discord';
+import { getChallengeAntiCheatThresholds } from '@/lib/challenges-manifest';
 
 // Runtime schema for the submission payload. Matches the shape written
 // by RC.report_completion + the caller-supplied user identity pulled
@@ -57,6 +58,27 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // 2b. Anti-cheat screening. Per-challenge thresholds in the manifest:
+  //     - completionTimeFrames < minPlausibleFrames → outright reject (impossible)
+  //     - completionTimeFrames < flagBelowFrames    → insert with pendingReview=true
+  //     A challenge with no thresholds skips screening (fail-open).
+  let pendingReview = false;
+  if (s.completionTimeFrames != null) {
+    const thresholds = await getChallengeAntiCheatThresholds(s.game, s.challengeName);
+    if (thresholds.minPlausibleFrames != null && s.completionTimeFrames < thresholds.minPlausibleFrames) {
+      return NextResponse.json(
+        {
+          error: 'implausible_time',
+          detail: `completionTimeFrames=${s.completionTimeFrames} is below minPlausibleFrames=${thresholds.minPlausibleFrames}`,
+        },
+        { status: 400 },
+      );
+    }
+    if (thresholds.flagBelowFrames != null && s.completionTimeFrames < thresholds.flagBelowFrames) {
+      pendingReview = true;
+    }
+  }
+
   // 3. Upsert user, insert run. Runs into the same User row on every
   //    submission from the same Google identity, keeping profile data fresh.
   try {
@@ -77,13 +99,15 @@ export async function POST(req: NextRequest) {
 
     // Look up the user's previous best on this challenge BEFORE the
     // insert so the new run isn't compared against itself. Same sort
-    // order the public leaderboard uses.
+    // order the public leaderboard uses. Pending runs aren't counted —
+    // a flagged time shouldn't masquerade as the user's PB until cleared.
     const priorBestRow = await prisma.run.findFirst({
       where: {
         userId: user.id,
         game: s.game,
         challengeName: s.challengeName,
         hiddenAt: null,
+        pendingReview: false,
       },
       orderBy: [
         { score: { sort: 'desc', nulls: 'last' } },
@@ -100,39 +124,47 @@ export async function POST(req: NextRequest) {
         score: s.score ?? null,
         completionTimeFrames: s.completionTimeFrames ?? null,
         clientReportedAt: s.clientReportedAt ? new Date(s.clientReportedAt) : null,
+        pendingReview,
         rawPayload: raw as object,
       },
     });
 
-    // First-ever run for this (user, challenge) is always a personal best.
-    const personalBest = !priorBestRow || isBetterRun(
-      { score: run.score, completionTimeFrames: run.completionTimeFrames },
-      priorBestRow,
-    );
+    // PB + Discord notification only fire if the run isn't pending review.
+    // A flagged run shouldn't claim a podium spot or trigger a celebration
+    // until an admin clears it.
+    const personalBest =
+      !pendingReview &&
+      (!priorBestRow ||
+        isBetterRun(
+          { score: run.score, completionTimeFrames: run.completionTimeFrames },
+          priorBestRow,
+        ));
 
-    // If the new run lands in the top 3 for the challenge, fire a
-    // Discord webhook (fire-and-forget; won't delay the API response,
-    // never blocks the success path).
-    void (async () => {
-      try {
-        const top3 = await getChallengeLeaderboard(s.game, s.challengeName, 3);
-        const idx = top3.findIndex((entry) => entry.runId === run.id);
-        if (idx === -1) return;  // not top 3, nothing to celebrate
-        const origin = req.nextUrl.origin;
-        await notifyDiscordTopPlacement({
-          rank: idx + 1,
-          playerName: user.name,
-          playerAvatarUrl: user.pictureUrl,
-          game: s.game,
-          challengeName: s.challengeName,
-          score: run.score,
-          completionTimeFrames: run.completionTimeFrames,
-          publicHref: `${origin}${challengeHref(s.game, s.challengeName)}`,
-        });
-      } catch (err) {
-        console.error('top-placement notification failed:', err);
-      }
-    })();
+    if (!pendingReview) {
+      // If the new run lands in the top 3 for the challenge, fire a
+      // Discord webhook (fire-and-forget; won't delay the API response,
+      // never blocks the success path).
+      void (async () => {
+        try {
+          const top3 = await getChallengeLeaderboard(s.game, s.challengeName, 3);
+          const idx = top3.findIndex((entry) => entry.runId === run.id);
+          if (idx === -1) return;  // not top 3, nothing to celebrate
+          const origin = req.nextUrl.origin;
+          await notifyDiscordTopPlacement({
+            rank: idx + 1,
+            playerName: user.name,
+            playerAvatarUrl: user.pictureUrl,
+            game: s.game,
+            challengeName: s.challengeName,
+            score: run.score,
+            completionTimeFrames: run.completionTimeFrames,
+            publicHref: `${origin}${challengeHref(s.game, s.challengeName)}`,
+          });
+        } catch (err) {
+          console.error('top-placement notification failed:', err);
+        }
+      })();
+    }
 
     return NextResponse.json(
       {
@@ -140,6 +172,7 @@ export async function POST(req: NextRequest) {
         runId: run.id,
         personalBest,
         previousBest: priorBestRow,
+        pendingReview,
       },
       { status: 201 },
     );

--- a/src/app/leaderboards/c/[game]/[challenge]/page.tsx
+++ b/src/app/leaderboards/c/[game]/[challenge]/page.tsx
@@ -40,6 +40,7 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
         game,
         challengeName,
         hiddenAt: null,
+        pendingReview: false,
         user: { bannedAt: null },
       },
       orderBy: { serverReceivedAt: 'asc' },

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -6,7 +6,9 @@ import { RefreshOnFocus } from '@/components/RefreshOnFocus';
 import {
   challengeHref,
   formatFrames,
+  getMyPendingRuns,
   getUserProfile,
+  type MyPendingRun,
   type UserProfile,
   type UserProfileChallenge,
 } from '@/lib/leaderboard';
@@ -23,7 +25,10 @@ export default async function MyDashboardPage() {
     return <SignedOut />;
   }
 
-  const profile = await getUserProfile(session.user.id);
+  const [profile, pending] = await Promise.all([
+    getUserProfile(session.user.id),
+    getMyPendingRuns(session.user.id),
+  ]);
   if (!profile) {
     // Session exists but user record is gone (e.g., admin-deleted between
     // sign-in and now). Treat as signed-out rather than crashing.
@@ -38,12 +43,48 @@ export default async function MyDashboardPage() {
         currentName={profile.name}
         currentAvatarUrl={profile.pictureUrl}
       />
+      {pending.length > 0 && <PendingPanel rows={pending} />}
       {profile.challenges.length === 0 ? (
         <EmptyState />
       ) : (
         <ChallengeTable rows={profile.challenges} />
       )}
     </div>
+  );
+}
+
+// Surfaces this user's own runs that are sitting in the anti-cheat review
+// queue. Hidden from the public leaderboards but the player should know
+// the submission landed; otherwise a fast run that vanishes feels like
+// data loss.
+function PendingPanel({ rows }: { rows: MyPendingRun[] }) {
+  return (
+    <section className="rounded-lg border border-amber-400/40 bg-amber-500/10 p-4">
+      <h2 className="font-display text-lg font-semibold text-amber-100">
+        {rows.length} run{rows.length === 1 ? '' : 's'} pending review
+      </h2>
+      <p className="text-xs text-amber-200/80 mt-1 mb-3">
+        Submitted, but the time was fast enough to trigger an automatic
+        review. An admin will approve or reject shortly — runs published
+        from the queue retroactively count for the leaderboard.
+      </p>
+      <ul className="space-y-1 text-sm">
+        {rows.map((r) => (
+          <li key={r.runId} className="flex items-center justify-between gap-3">
+            <Link
+              href={challengeHref(r.game, r.challengeName)}
+              className="truncate text-amber-100 hover:text-white"
+            >
+              {r.game} — {r.challengeName}
+            </Link>
+            <span className="shrink-0 font-mono text-xs text-amber-200 tabular-nums">
+              {formatFrames(r.completionTimeFrames)}
+              {r.score != null && ` · ${r.score.toLocaleString()} pts`}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -13,6 +13,7 @@ export interface AdminKpis {
   bannedUsers: number;
   totalRuns: number;
   hiddenRuns: number;
+  pendingRuns: number;
   runsLast24h: number;
   runsLast7d: number;
   newUsersLast7d: number;
@@ -25,20 +26,21 @@ export async function getAdminKpis(): Promise<AdminKpis> {
 
   const [
     totalUsers, bannedUsers,
-    totalRuns,  hiddenRuns,
+    totalRuns,  hiddenRuns, pendingRuns,
     runsLast24h, runsLast7d, newUsersLast7d,
   ] = await Promise.all([
     prisma.user.count(),
     prisma.user.count({ where: { bannedAt: { not: null } } }),
     prisma.run.count(),
     prisma.run.count({ where: { hiddenAt: { not: null } } }),
+    prisma.run.count({ where: { pendingReview: true, hiddenAt: null } }),
     prisma.run.count({ where: { serverReceivedAt: { gte: dayAgo } } }),
     prisma.run.count({ where: { serverReceivedAt: { gte: weekAgo } } }),
     prisma.user.count({ where: { createdAt: { gte: weekAgo } } }),
   ]);
 
   return {
-    totalUsers, bannedUsers, totalRuns, hiddenRuns,
+    totalUsers, bannedUsers, totalRuns, hiddenRuns, pendingRuns,
     runsLast24h, runsLast7d, newUsersLast7d,
   };
 }
@@ -359,6 +361,40 @@ export async function listAuditLog(opts: {
 }
 
 // ---------------------------------------------------------------------------
+// Pending review queue. Runs that came in below the manifest's
+// flagBelowFrames threshold and haven't yet been approved or rejected
+// by an admin. The queue lives at /admin/pending; cleared rows leave
+// it via approveRunAction / rejectRunAction.
+// ---------------------------------------------------------------------------
+export interface PendingRunRow {
+  id: string;
+  game: string;
+  challengeName: string;
+  score: number | null;
+  completionTimeFrames: number | null;
+  serverReceivedAt: Date;
+  user: { id: string; name: string };
+}
+
+export async function listPendingRuns(): Promise<PendingRunRow[]> {
+  const rows = await prisma.run.findMany({
+    where: { pendingReview: true, hiddenAt: null },
+    orderBy: { serverReceivedAt: 'desc' },
+    take: 200,
+    select: {
+      id: true,
+      game: true,
+      challengeName: true,
+      score: true,
+      completionTimeFrames: true,
+      serverReceivedAt: true,
+      user: { select: { id: true, name: true } },
+    },
+  });
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
 // Site setting (singleton)
 // ---------------------------------------------------------------------------
 export interface SiteBanner {
@@ -419,6 +455,7 @@ export async function listAdminChallengeStats(): Promise<AdminChallengeStat[]> {
             game: g.game,
             challengeName: g.challengeName,
             hiddenAt: null,
+            pendingReview: false,
             user: { bannedAt: null },
             completionTimeFrames: { not: null },
           },

--- a/src/lib/challenges-manifest.ts
+++ b/src/lib/challenges-manifest.ts
@@ -16,6 +16,11 @@ interface RawManifestChallenge {
   name: string;
   category?: string;
   difficulty?: string;
+  // Anti-cheat thresholds (frames). The submit endpoint uses these to
+  // reject impossible runs outright and route suspicious-but-possible
+  // runs into the /admin/pending review queue.
+  minPlausibleFrames?: number;
+  flagBelowFrames?: number;
 }
 interface RawManifestGame {
   name: string;
@@ -32,6 +37,11 @@ export interface ChallengeMeta {
   challengeName: string;
   category?: string;
   difficulty?: string;
+  // Anti-cheat thresholds, copied from the manifest. Both are optional —
+  // a challenge without them gets no automated screening (fail-open so a
+  // missing field never silently rejects legitimate runs).
+  minPlausibleFrames?: number;
+  flagBelowFrames?: number;
 }
 
 export interface GameMeta {
@@ -88,6 +98,22 @@ export async function getGamesManifest(): Promise<Map<string, GameMeta>> {
   return (await loadManifest()).games;
 }
 
+// Lookup helper for the submit endpoint. Returns the (minPlausibleFrames,
+// flagBelowFrames) pair for a (game, challenge) tuple. Either field may
+// be undefined — callers must treat absence as "no threshold" (fail-open).
+export async function getChallengeAntiCheatThresholds(
+  game: string,
+  challengeName: string,
+): Promise<{ minPlausibleFrames?: number; flagBelowFrames?: number }> {
+  const map = await getChallengesManifest();
+  const meta = map.get(manifestKey(game, challengeName));
+  if (!meta) return {};
+  return {
+    minPlausibleFrames: meta.minPlausibleFrames,
+    flagBelowFrames:    meta.flagBelowFrames,
+  };
+}
+
 // Pure transform — exported so tests can hit it without touching fetch.
 // Returns both per-challenge AND per-game maps in one pass through the
 // raw manifest tree.
@@ -109,6 +135,8 @@ export function parseManifest(data: RawManifest): ParsedManifest {
         challengeName: c.name,
         category: c.category,
         difficulty: c.difficulty,
+        minPlausibleFrames: typeof c.minPlausibleFrames === 'number' ? c.minPlausibleFrames : undefined,
+        flagBelowFrames:    typeof c.flagBelowFrames    === 'number' ? c.flagBelowFrames    : undefined,
       });
     }
   }

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -76,6 +76,7 @@ export async function getChallengeLeaderboard(
     game,
     challengeName,
     hiddenAt: null,
+    pendingReview: false,
     user: { bannedAt: null },
     ...(since ? { serverReceivedAt: { gte: since } } : {}),
   };
@@ -156,6 +157,7 @@ export async function listChallengesWithRuns() {
     by: ['game', 'challengeName'],
     where: {
       hiddenAt: null,
+      pendingReview: false,
       user: { bannedAt: null },
     },
     _count: { _all: true },
@@ -186,6 +188,7 @@ export async function listChallengeSummaries(game?: string): Promise<ChallengeSu
     by: ['game', 'challengeName'],
     where: {
       hiddenAt: null,
+      pendingReview: false,
       user: { bannedAt: null },
       ...(game ? { game } : {}),
     },
@@ -206,6 +209,7 @@ export async function listChallengeSummaries(game?: string): Promise<ChallengeSu
             game: g.game,
             challengeName: g.challengeName,
             hiddenAt: null,
+            pendingReview: false,
             user: { bannedAt: null },
           },
         }),
@@ -245,7 +249,7 @@ export async function listGames(): Promise<GameSummary[]> {
   const [games, manifest] = await Promise.all([
     prisma.run.groupBy({
       by: ['game'],
-      where: { hiddenAt: null, user: { bannedAt: null } },
+      where: { hiddenAt: null, pendingReview: false, user: { bannedAt: null } },
       _count: { _all: true },
       orderBy: { game: 'asc' },
     }),
@@ -256,11 +260,11 @@ export async function listGames(): Promise<GameSummary[]> {
       const [challengeRows, playerRows] = await Promise.all([
         prisma.run.groupBy({
           by: ['challengeName'],
-          where: { game: g.game, hiddenAt: null, user: { bannedAt: null } },
+          where: { game: g.game, hiddenAt: null, pendingReview: false, user: { bannedAt: null } },
         }),
         prisma.run.groupBy({
           by: ['userId'],
-          where: { game: g.game, hiddenAt: null, user: { bannedAt: null } },
+          where: { game: g.game, hiddenAt: null, pendingReview: false, user: { bannedAt: null } },
         }),
       ]);
       return {
@@ -281,11 +285,11 @@ export async function getOverallStats(): Promise<{
   totalChallenges: number;
 }> {
   const [totalRuns, totalPlayers, challengeGroups] = await Promise.all([
-    prisma.run.count({ where: { hiddenAt: null, user: { bannedAt: null } } }),
-    prisma.user.count({ where: { bannedAt: null, runs: { some: { hiddenAt: null } } } }),
+    prisma.run.count({ where: { hiddenAt: null, pendingReview: false, user: { bannedAt: null } } }),
+    prisma.user.count({ where: { bannedAt: null, runs: { some: { hiddenAt: null, pendingReview: false } } } }),
     prisma.run.groupBy({
       by: ['game', 'challengeName'],
-      where: { hiddenAt: null, user: { bannedAt: null } },
+      where: { hiddenAt: null, pendingReview: false, user: { bannedAt: null } },
     }),
   ]);
   return { totalRuns, totalPlayers, totalChallenges: challengeGroups.length };
@@ -319,7 +323,7 @@ const STREAK_WINDOW_MS = 60 * 60 * 1000;  // 1 hour
 
 export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
   const rows = await prisma.run.findMany({
-    where: { hiddenAt: null, user: { bannedAt: null } },
+    where: { hiddenAt: null, pendingReview: false, user: { bannedAt: null } },
     orderBy: { serverReceivedAt: 'desc' },
     take: limit,
     select: {
@@ -349,6 +353,7 @@ export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
             game: r.game,
             challengeName: r.challengeName,
             hiddenAt: null,
+            pendingReview: false,
             user: { bannedAt: null },
             serverReceivedAt: { lt: r.serverReceivedAt },
           },
@@ -362,6 +367,7 @@ export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
             game: r.game,
             challengeName: r.challengeName,
             hiddenAt: null,
+            pendingReview: false,
             serverReceivedAt: { lt: r.serverReceivedAt },
           },
           orderBy: [
@@ -378,6 +384,7 @@ export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
             game: r.game,
             challengeName: r.challengeName,
             hiddenAt: null,
+            pendingReview: false,
             serverReceivedAt: { gte: streakSince, lte: r.serverReceivedAt },
           },
         }),
@@ -451,7 +458,7 @@ export async function getUserProfile(userId: string): Promise<UserProfile | null
   if (!user || user.bannedAt) return null;
 
   const userRuns = await prisma.run.findMany({
-    where: { userId, hiddenAt: null },
+    where: { userId, hiddenAt: null, pendingReview: false },
     orderBy: [
       { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
       { score: { sort: 'desc', nulls: 'last' } },
@@ -516,6 +523,41 @@ export async function getUserProfile(userId: string): Promise<UserProfile | null
 
 export function userProfileHref(userId: string): string {
   return `/u/${encodeURIComponent(userId)}`;
+}
+
+// /me-only — surfaces the signed-in user's own runs that are sitting in
+// the anti-cheat review queue, so they know the submission landed but
+// hasn't been published yet. Public profiles never expose this.
+export interface MyPendingRun {
+  runId: string;
+  game: string;
+  challengeName: string;
+  score: number | null;
+  completionTimeFrames: number | null;
+  serverReceivedAt: Date;
+}
+export async function getMyPendingRuns(userId: string): Promise<MyPendingRun[]> {
+  const rows = await prisma.run.findMany({
+    where: { userId, pendingReview: true, hiddenAt: null },
+    orderBy: { serverReceivedAt: 'desc' },
+    take: 20,
+    select: {
+      id: true,
+      game: true,
+      challengeName: true,
+      score: true,
+      completionTimeFrames: true,
+      serverReceivedAt: true,
+    },
+  });
+  return rows.map((r) => ({
+    runId: r.id,
+    game: r.game,
+    challengeName: r.challengeName,
+    score: r.score,
+    completionTimeFrames: r.completionTimeFrames,
+    serverReceivedAt: r.serverReceivedAt,
+  }));
 }
 
 // Compare two run metric pairs using the same rule the leaderboard uses

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -59,6 +59,47 @@ describe('parseManifest', () => {
     expect(meta?.difficulty).toBeUndefined();
   });
 
+  test('parses anti-cheat thresholds when present', () => {
+    const m = parseManifest({
+      games: [{
+        name: 'CV',
+        challenges: [{
+          name: 'Bat',
+          minPlausibleFrames: 600,
+          flagBelowFrames: 1500,
+        }],
+      }],
+    });
+    const meta = m.challenges.get(manifestKey('CV', 'Bat'));
+    expect(meta?.minPlausibleFrames).toBe(600);
+    expect(meta?.flagBelowFrames).toBe(1500);
+  });
+
+  test('anti-cheat thresholds are undefined when manifest omits them (fail-open)', () => {
+    const m = parseManifest({
+      games: [{ name: 'CV', challenges: [{ name: 'Bat' }] }],
+    });
+    const meta = m.challenges.get(manifestKey('CV', 'Bat'));
+    expect(meta?.minPlausibleFrames).toBeUndefined();
+    expect(meta?.flagBelowFrames).toBeUndefined();
+  });
+
+  test('non-numeric anti-cheat thresholds are ignored (treated as missing)', () => {
+    const m = parseManifest({
+      games: [{
+        name: 'CV',
+        challenges: [{
+          name: 'Bat',
+          minPlausibleFrames: 'not a number' as unknown as number,
+          flagBelowFrames: null as unknown as number,
+        }],
+      }],
+    });
+    const meta = m.challenges.get(manifestKey('CV', 'Bat'));
+    expect(meta?.minPlausibleFrames).toBeUndefined();
+    expect(meta?.flagBelowFrames).toBeUndefined();
+  });
+
   test('extracts per-game boxArtUrl / description into the games map', () => {
     const m = parseManifest({
       games: [


### PR DESCRIPTION
## Summary
End-to-end anti-cheat plumbing. Per-challenge thresholds in \`challenges.json\` (assets repo, v1.22.0) drive a two-tier screen on the submit path:

| Submitted time | Outcome |
|---|---|
| < \`minPlausibleFrames\` | Reject 400 \`implausible_time\` |
| < \`flagBelowFrames\` | Insert with \`pendingReview=true\` (hidden from public, visible to owner on /me, queued for admin review) |
| ≥ \`flagBelowFrames\` | Publish normally |
| _(no thresholds in manifest)_ | Skip screening (fail-open) |

Heuristic in the assets repo: \`flagBelowFrames ≈ 0.80 × SSS\`, \`minPlausibleFrames ≈ 0.33 × SSS\`.

## Schema
\`Run.pendingReview Boolean DEFAULT false\` + index. Migration \`20260503000000_run_pending_review\`.

## What this changes for users

**Players** — A flagged run shows up immediately on /me in an amber "pending review" panel, so they know the submission landed and is waiting on an admin. It's hidden from public leaderboards until cleared.

**Admins** — New \`/admin/pending\` page with Approve / Reject buttons. Approving clears the flag and the run goes live retroactively (it'll appear in leaderboards on the next request thanks to revalidatePath). Rejecting hides the run with a reason; the row stays in the DB for forensic review. Both actions write to the audit log with a (game, challenge, user, time) snapshot.

The dashboard surfaces an amber call-to-action above the KPI grid whenever the queue is non-empty.

## Visibility filtering
Every public-facing query in \`src/lib/leaderboard.ts\` now filters \`pendingReview: false\` alongside \`hiddenAt: null\`: \`getChallengeLeaderboard\`, \`listChallengesWithRuns\`, \`listChallengeSummaries\`, \`listGames\`, \`getOverallStats\`, \`getRecentRuns\` (+ its three sub-queries), \`getUserProfile\`. Also the \`firstEverCompleter\` lookup on \`/leaderboards/c/[game]/[challenge]\`.

## Daily / Weekly tabs (#2 from the bundle)
Already shipped in an earlier release as \`WindowTabs\` on the per-challenge page (\`?window=daily|weekly|all\`). Verified end-to-end during this work: empty-state messaging is helpful ("No runs in the last 24 hours — try the All Time tab"), default behavior is sane (no param = All Time), and the per-window queries now also exclude pending runs. No additional changes needed.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 56/56 passing (53 → 56, three new parseManifest cases)
- [x] \`npm run build\` — green; all routes registered including \`/admin/pending\`
- [ ] After deploy + migration applied:
  - [ ] Submit a run with completionTimeFrames between flagBelow and SSS → lands in queue, appears on /me amber panel, NOT on public leaderboard
  - [ ] Submit a run below minPlausibleFrames → server returns 400 implausible_time
  - [ ] Approve from /admin/pending → run appears on public leaderboard, audit log shows approve_run
  - [ ] Reject from /admin/pending → run vanishes from owner's /me panel, audit log shows reject_run with reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)