### PR TITLE
fix(submit): disable minPlausibleFrames hard-reject (use soft flag only)

### DIFF
--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -59,21 +59,20 @@ export async function POST(req: NextRequest) {
   }
 
   // 2b. Anti-cheat screening. Per-challenge thresholds in the manifest:
-  //     - completionTimeFrames < minPlausibleFrames → outright reject (impossible)
+  //     - completionTimeFrames < minPlausibleFrames → REJECT (currently disabled — see below)
   //     - completionTimeFrames < flagBelowFrames    → insert with pendingReview=true
   //     A challenge with no thresholds skips screening (fail-open).
+  //
+  // The minPlausibleFrames REJECTION is temporarily disabled: the early
+  // thresholds turned out too aggressive for legitimate fast runs, and
+  // a hard 400 is a worse player experience than a soft "queued for
+  // review" while we tune them. Soft flagging is enough — admins can
+  // catch impossible submissions in /admin/pending and reject them
+  // manually. Re-enable when thresholds are calibrated against real
+  // player data.
   let pendingReview = false;
   if (s.completionTimeFrames != null) {
     const thresholds = await getChallengeAntiCheatThresholds(s.game, s.challengeName);
-    if (thresholds.minPlausibleFrames != null && s.completionTimeFrames < thresholds.minPlausibleFrames) {
-      return NextResponse.json(
-        {
-          error: 'implausible_time',
-          detail: `completionTimeFrames=${s.completionTimeFrames} is below minPlausibleFrames=${thresholds.minPlausibleFrames}`,
-        },
-        { status: 400 },
-      );
-    }
     if (thresholds.flagBelowFrames != null && s.completionTimeFrames < thresholds.flagBelowFrames) {
       pendingReview = true;
     }


### PR DESCRIPTION
## Summary
The \`implausible_time\` 400 rejection was firing on legitimate fast runs because the per-challenge \`minPlausibleFrames\` thresholds were initial guesses, not calibrated against real play data. Hard-rejecting a record is worse UX than queuing it for review.

Disabled the reject block. \`flagBelowFrames\` (soft "queued for review") still runs — admins can catch impossible submissions in \`/admin/pending\` manually.

Re-enable when we have real player data to set the floors against.

## Test plan
- [x] typecheck clean
- [ ] After deploy: submit a fast run that previously 400'd → lands in DB (possibly as pendingReview=true), no error