### PR TITLE
feat(api): per-IP rate limit on /api/runs (10/min sliding window)

### DIFF
--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -5,6 +5,7 @@ import { verifySubmissionSecret } from '@/lib/auth';
 import { isBetterRun, getChallengeLeaderboard, challengeHref } from '@/lib/leaderboard';
 import { notifyDiscordTopPlacement } from '@/lib/discord';
 import { getChallengeAntiCheatThresholds } from '@/lib/challenges-manifest';
+import { rateLimit } from '@/lib/rate-limit';
 
 // Runtime schema for the submission payload. Matches the shape written
 // by RC.report_completion + the caller-supplied user identity pulled
@@ -26,11 +27,45 @@ const SubmissionSchema = z.object({
 
 export const runtime = 'nodejs';
 
+// Per-IP rate limit for the submit endpoint. The shared submission
+// secret lives in the Electron binary — anyone who installs the app can
+// extract it and start submitting. The most likely abuse is a spam
+// flood (curl loop with random googleSubs creating fake user records).
+// 10/min/IP is way above any legit player's submission rate (challenges
+// take 30s+) but caps a flood at ~600/hour/IP — small enough that the
+// /admin/pending queue can keep up with manual cleanup.
+const RUNS_RATE_MAX        = 10;
+const RUNS_RATE_WINDOW_MS  = 60_000;
+
+function clientIp(req: NextRequest): string {
+  const xff = req.headers.get('x-forwarded-for');
+  if (xff) return xff.split(',')[0].trim();
+  return req.headers.get('x-real-ip')?.trim() ?? 'unknown';
+}
+
 export async function POST(req: NextRequest) {
   // 1. Auth: shared-secret header. Leaky (lives in the Electron binary)
   //    but stops casual curl abuse. Moderation is the real trust backstop.
   if (!verifySubmissionSecret(req.headers.get('x-rc-submission-secret'))) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  // 1b. Rate limit per source IP. Authenticated callers still get
+  //     limited so a leaked secret can't fuel an unlimited flood.
+  const ip    = clientIp(req);
+  const limit = rateLimit(`runs:${ip}`, RUNS_RATE_MAX, RUNS_RATE_WINDOW_MS);
+  if (!limit.allowed) {
+    return NextResponse.json(
+      { error: 'rate_limited', detail: 'Too many submissions; try again shortly.' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After':           String(Math.ceil(limit.resetMs / 1000)),
+          'X-RateLimit-Limit':     String(RUNS_RATE_MAX),
+          'X-RateLimit-Remaining': '0',
+        },
+      },
+    );
   }
 
   // 2. Parse + validate.

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,83 @@
+// In-memory sliding-window rate limiter.
+//
+// Why in-memory: at our scale (a few hundred users / a few hundred
+// requests per day) we don't need Redis. Each Next.js process tracks
+// its own buckets; on a multi-instance deploy a determined attacker
+// could get N×limit through, but that's still N×10/min, not infinity.
+//
+// Memory bound: a periodic sweep evicts buckets whose newest entry is
+// older than the window — so the Map size tracks active IPs only,
+// not lifetime IPs.
+
+interface Bucket {
+  // Sorted ascending; oldest at index 0.
+  timestamps: number[];
+}
+
+const buckets = new Map<string, Bucket>();
+
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULT_MAX       = 10;
+const SWEEP_INTERVAL_MS = 60_000;
+
+// Periodic cleanup so the Map doesn't grow unbounded on a long-running
+// process. unref() so the timer doesn't prevent Node from exiting in
+// tests / scripts that import this module.
+const sweep = setInterval(() => {
+  const cutoff = Date.now() - DEFAULT_WINDOW_MS;
+  for (const [key, bucket] of buckets) {
+    const fresh = bucket.timestamps.filter((t) => t > cutoff);
+    if (fresh.length === 0) {
+      buckets.delete(key);
+    } else {
+      bucket.timestamps = fresh;
+    }
+  }
+}, SWEEP_INTERVAL_MS);
+sweep.unref?.();
+
+export interface RateLimitResult {
+  allowed: boolean;
+  // Requests still allowed in the current window after this call.
+  remaining: number;
+  // Milliseconds until the oldest in-window request falls out — i.e.
+  // when the next slot opens up. 0 when allowed=true.
+  resetMs: number;
+}
+
+// Records one hit for `key` and returns whether it's within the
+// allowed rate. Sliding-window: prunes timestamps older than `windowMs`
+// before counting, so the limit is "max requests in the last windowMs".
+export function rateLimit(
+  key: string,
+  max: number = DEFAULT_MAX,
+  windowMs: number = DEFAULT_WINDOW_MS,
+  now: number = Date.now(),
+): RateLimitResult {
+  const cutoff = now - windowMs;
+  const bucket = buckets.get(key) ?? { timestamps: [] };
+  // In-place prune — cheap because timestamps is small.
+  bucket.timestamps = bucket.timestamps.filter((t) => t > cutoff);
+
+  if (bucket.timestamps.length >= max) {
+    const oldest = bucket.timestamps[0];
+    return {
+      allowed: false,
+      remaining: 0,
+      resetMs: Math.max(0, oldest + windowMs - now),
+    };
+  }
+
+  bucket.timestamps.push(now);
+  buckets.set(key, bucket);
+  return {
+    allowed: true,
+    remaining: max - bucket.timestamps.length,
+    resetMs: 0,
+  };
+}
+
+// Test helper — wipes all bucket state. Not for production use.
+export function _resetRateLimitForTests(): void {
+  buckets.clear();
+}

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,58 @@
+import {
+  rateLimit,
+  _resetRateLimitForTests,
+} from '../src/lib/rate-limit';
+
+beforeEach(() => {
+  _resetRateLimitForTests();
+});
+
+describe('rateLimit', () => {
+  test('allows up to `max` requests in a window', () => {
+    for (let i = 0; i < 5; i++) {
+      const r = rateLimit('k', 5, 60_000, 1_000_000 + i);
+      expect(r.allowed).toBe(true);
+      expect(r.remaining).toBe(4 - i);
+    }
+  });
+
+  test('rejects the (max+1)th request in the window', () => {
+    for (let i = 0; i < 3; i++) rateLimit('k', 3, 60_000, 1_000_000 + i);
+    const r = rateLimit('k', 3, 60_000, 1_000_005);
+    expect(r.allowed).toBe(false);
+    expect(r.remaining).toBe(0);
+    expect(r.resetMs).toBeGreaterThan(0);
+  });
+
+  test('resetMs counts down to when the oldest request falls out of window', () => {
+    rateLimit('k', 1, 1000, 1_000_000);                  // first request at t=1_000_000
+    const r = rateLimit('k', 1, 1000, 1_000_400);        // second at t+400, denied
+    expect(r.allowed).toBe(false);
+    // Oldest entry (t=1_000_000) falls out at t=1_001_000; 600ms remaining.
+    expect(r.resetMs).toBe(600);
+  });
+
+  test('window slides — old entries don\'t count after windowMs', () => {
+    rateLimit('k', 2, 1000, 1_000_000);                  // 2 requests inside window
+    rateLimit('k', 2, 1000, 1_000_500);
+    const denied = rateLimit('k', 2, 1000, 1_000_800);   // 3rd at 800ms — denied
+    expect(denied.allowed).toBe(false);
+    // Now jump past the first request's window expiry (1_001_000+).
+    const allowed = rateLimit('k', 2, 1000, 1_002_000);  // first dropped, room for one
+    expect(allowed.allowed).toBe(true);
+  });
+
+  test('different keys are tracked independently', () => {
+    rateLimit('a', 1, 60_000, 1_000_000);
+    const a2 = rateLimit('a', 1, 60_000, 1_000_001);
+    expect(a2.allowed).toBe(false);
+    const b1 = rateLimit('b', 1, 60_000, 1_000_001);
+    expect(b1.allowed).toBe(true);
+  });
+
+  test('allowed requests report remaining correctly', () => {
+    expect(rateLimit('k', 3, 60_000, 1_000_000).remaining).toBe(2);
+    expect(rateLimit('k', 3, 60_000, 1_000_001).remaining).toBe(1);
+    expect(rateLimit('k', 3, 60_000, 1_000_002).remaining).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Caps spam abuse of the submit endpoint. The shared submission secret is bundled in the Electron app (anyone who installs can extract); without a rate limit a curl loop could create thousands of fake user records in seconds.

## Approach
Per-IP sliding window: 10 requests / 60s. In-memory (no Redis dependency) — fine at our scale; multi-instance worst case is N×limit which is still N×10/min.

429 response includes \`Retry-After\` + \`X-RateLimit-Limit\` + \`X-RateLimit-Remaining\` headers so a client that's hitting the wall can back off intelligently.

## Test plan
- [x] typecheck clean
- [x] 62/62 tests passing (56 → 62, six new rate-limit cases)
- [ ] After deploy: \`for i in 1..15; curl -H 'x-rc-submission-secret: ...' POST /api/runs\` — first 10 succeed (or fail validation), 11-15 return 429 with Retry-After
- [ ] Real player submissions are unaffected (challenges take 30s+, way under 10/min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)