### PR TITLE
feat(grading): per-run SS-grade chips + Trophy Room on profile pages

### DIFF
--- a/src/app/leaderboards/c/[game]/[challenge]/page.tsx
+++ b/src/app/leaderboards/c/[game]/[challenge]/page.tsx
@@ -12,6 +12,9 @@ import {
   type LeaderboardWindow,
   type LeaderboardView,
 } from '@/lib/leaderboard';
+import { getChallengesManifest, manifestKey } from '@/lib/challenges-manifest';
+import { gradeForRun } from '@/lib/grading';
+import { GradeChip } from '@/components/GradeChip';
 
 export const dynamic = 'force-dynamic';
 
@@ -32,7 +35,7 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
   // can highlight "you"), and the chronologically-first completer of this
   // challenge (so they get a 🥇 trophy regardless of current rank — risk-
   // taker recognition that persists even if they later get out-run).
-  const [entries, session, firstEverCompleter] = await Promise.all([
+  const [entries, session, firstEverCompleter, manifest] = await Promise.all([
     getChallengeLeaderboard(game, challengeName, 50, activeWindow, activeView),
     auth(),
     prisma.run.findFirst({
@@ -46,7 +49,10 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
       orderBy: { serverReceivedAt: 'asc' },
       select: { userId: true },
     }),
+    getChallengesManifest(),
   ]);
+  // Grade thresholds for THIS challenge (looked up once, reused per row).
+  const gradeThresholds = manifest.get(manifestKey(game, challengeName))?.gradeThresholds;
   const meId = session?.user?.id ?? null;
   const firstEverUserId = firstEverCompleter?.userId ?? null;
 
@@ -77,6 +83,7 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
                 <th className="py-2 pr-2">Player</th>
                 <th className="py-2 pr-2 text-right">Score</th>
                 <th className="py-2 pr-2 text-right">Time</th>
+                <th className="py-2 pr-2 text-right">Grade</th>
                 <th className="py-2 pr-2 text-right hidden sm:table-cell">Submitted</th>
               </tr>
             </thead>
@@ -133,6 +140,9 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
                     </td>
                     <td className="py-2 pr-2 text-right font-mono text-slate-200">
                       {formatFrames(e.completionTimeFrames)}
+                    </td>
+                    <td className="py-2 pr-2 text-right">
+                      <GradeChip grade={gradeForRun(gradeThresholds, e.completionTimeFrames)} size="md" />
                     </td>
                     <td className="py-2 pr-2 text-right text-xs text-slate-500 hidden sm:table-cell">
                       {new Date(e.serverReceivedAt).toLocaleDateString()}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -12,6 +12,8 @@ import {
   type UserProfile,
   type UserProfileChallenge,
 } from '@/lib/leaderboard';
+import { GradeChip } from '@/components/GradeChip';
+import { TrophyRoom } from '@/components/TrophyRoom';
 
 export const dynamic = 'force-dynamic';
 
@@ -44,6 +46,7 @@ export default async function MyDashboardPage() {
         currentAvatarUrl={profile.pictureUrl}
       />
       {pending.length > 0 && <PendingPanel rows={pending} />}
+      <TrophyRoom trophies={profile.trophies} catalog={profile.catalog} />
       {profile.challenges.length === 0 ? (
         <EmptyState />
       ) : (
@@ -182,6 +185,7 @@ function ChallengeTable({ rows }: { rows: UserProfileChallenge[] }) {
               <th className="py-2 pr-2">Challenge</th>
               <th className="py-2 pr-2 text-right">Score</th>
               <th className="py-2 pr-2 text-right">Time</th>
+              <th className="py-2 pr-2 text-right">Grade</th>
               <th className="py-2 pr-2 text-right">Rank</th>
               <th className="py-2 pr-2 text-right hidden sm:table-cell">Attempts</th>
             </tr>
@@ -203,6 +207,9 @@ function ChallengeTable({ rows }: { rows: UserProfileChallenge[] }) {
                 </td>
                 <td className="py-2 pr-2 text-right font-mono text-slate-200 tabular-nums">
                   {formatFrames(r.bestRun.completionTimeFrames)}
+                </td>
+                <td className="py-2 pr-2 text-right">
+                  <GradeChip grade={r.bestGrade} />
                 </td>
                 <td className="py-2 pr-2 text-right font-mono">
                   {r.rank ? <RankBadge rank={r.rank} /> : <span className="text-slate-500">—</span>}

--- a/src/app/u/[userId]/page.tsx
+++ b/src/app/u/[userId]/page.tsx
@@ -8,6 +8,8 @@ import {
   type UserProfile,
   type UserProfileChallenge,
 } from '@/lib/leaderboard';
+import { GradeChip } from '@/components/GradeChip';
+import { TrophyRoom } from '@/components/TrophyRoom';
 
 export const dynamic = 'force-dynamic';
 
@@ -25,6 +27,7 @@ export default async function UserProfilePage({ params }: PageProps) {
   return (
     <div className="space-y-8">
       <Hero profile={profile} />
+      <TrophyRoom trophies={profile.trophies} catalog={profile.catalog} />
       {profile.challenges.length === 0 ? (
         <p className="text-slate-400">
           No runs yet — once {profile.name} finishes a challenge, it'll appear here.
@@ -80,6 +83,7 @@ function ChallengeTable({ rows }: { rows: UserProfileChallenge[] }) {
               <th className="py-2 pr-2">Challenge</th>
               <th className="py-2 pr-2 text-right">Score</th>
               <th className="py-2 pr-2 text-right">Time</th>
+              <th className="py-2 pr-2 text-right">Grade</th>
               <th className="py-2 pr-2 text-right">Rank</th>
               <th className="py-2 pr-2 text-right hidden sm:table-cell">Attempts</th>
             </tr>
@@ -101,6 +105,9 @@ function ChallengeTable({ rows }: { rows: UserProfileChallenge[] }) {
                 </td>
                 <td className="py-2 pr-2 text-right font-mono text-slate-200 tabular-nums">
                   {formatFrames(r.bestRun.completionTimeFrames)}
+                </td>
+                <td className="py-2 pr-2 text-right">
+                  <GradeChip grade={r.bestGrade} />
                 </td>
                 <td className="py-2 pr-2 text-right font-mono">
                   {r.rank ? <RankBadge rank={r.rank} /> : <span className="text-slate-500">—</span>}

--- a/src/components/GradeChip.tsx
+++ b/src/components/GradeChip.tsx
@@ -1,0 +1,28 @@
+import { gradeChipClass, type Grade } from '@/lib/grading';
+
+// Compact grade pill. Used inline next to a completion time on
+// leaderboard rows, profile tables, activity feed, etc. Pure
+// presentational — caller computes the grade from a (thresholds,
+// frames) pair via gradeForRun() and passes it in.
+//
+// `grade=null` renders a muted "—" so unattempted / un-gradable
+// rows don't shift the layout.
+export function GradeChip({
+  grade,
+  size = 'sm',
+}: {
+  grade: Grade | null;
+  size?: 'sm' | 'md';
+}) {
+  const sizeCls = size === 'md'
+    ? 'px-2.5 py-1 text-xs'
+    : 'px-1.5 py-0.5 text-[10px]';
+  return (
+    <span
+      className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums tracking-wider ${sizeCls} ${gradeChipClass(grade)}`}
+      title={grade ? `Grade ${grade}` : 'No grade'}
+    >
+      {grade ?? '—'}
+    </span>
+  );
+}

--- a/src/components/TrophyRoom.tsx
+++ b/src/components/TrophyRoom.tsx
@@ -1,0 +1,121 @@
+import Link from 'next/link';
+import { GradeChip } from './GradeChip';
+import { GRADE_ORDER, type Grade, type TrophyStats } from '@/lib/grading';
+import { challengeHref } from '@/lib/leaderboard';
+import type { TrophyCatalogEntry } from '@/lib/leaderboard';
+
+// Player's grade-tally surface. Three layers:
+//
+//   1. Top progress bars — SSS%, SS+%, attempted%. Single eyeball
+//      sweep tells you how complete the player's wall is.
+//   2. Tally row — per-grade counts using the same chips that appear
+//      on leaderboard rows, so the visual vocabulary is consistent.
+//   3. Per-challenge breakdown — every challenge in the manifest
+//      with the player's best grade or "—" for unattempted. Drives
+//      the "fill in the gaps" hook.
+//
+// Pure presentational — caller already computed the stats + catalog
+// in lib/leaderboard.ts:getUserProfile.
+
+export function TrophyRoom({
+  trophies,
+  catalog,
+}: {
+  trophies: TrophyStats;
+  catalog: TrophyCatalogEntry[];
+}) {
+  return (
+    <section className="rounded-lg border border-slate-700 bg-slate-900/60 p-5 space-y-5">
+      <header className="flex items-baseline justify-between">
+        <h2 className="font-display text-xl font-semibold text-white">Trophies</h2>
+        <span className="text-xs text-slate-500">
+          best grade per challenge across the catalog
+        </span>
+      </header>
+
+      <ProgressRow label="SSS rate"          pct={trophies.sssPct}        accent="bg-amber-400"  num={trophies.tally.SSS}                       denom={trophies.totalChallenges} />
+      <ProgressRow label="SS or better"      pct={trophies.ssOrBetterPct} accent="bg-slate-200"  num={trophies.tally.SSS + trophies.tally.SS}   denom={trophies.totalChallenges} />
+      <ProgressRow label="Attempted"         pct={trophies.attemptedPct}  accent="bg-emerald-500" num={trophies.attemptedChallenges}             denom={trophies.totalChallenges} />
+
+      <div className="flex flex-wrap items-center gap-3 pt-1">
+        {GRADE_ORDER.map((g) => (
+          <div key={g} className="flex items-center gap-1.5">
+            <GradeChip grade={g as Grade} size="md" />
+            <span className="text-sm text-slate-300 tabular-nums">×{trophies.tally[g]}</span>
+          </div>
+        ))}
+      </div>
+
+      <CatalogList catalog={catalog} />
+    </section>
+  );
+}
+
+function ProgressRow({
+  label,
+  pct,
+  accent,
+  num,
+  denom,
+}: {
+  label: string;
+  pct: number;
+  accent: string;
+  num: number;
+  denom: number;
+}) {
+  const clamped = Math.max(0, Math.min(100, pct));
+  return (
+    <div>
+      <div className="flex items-baseline justify-between text-xs mb-1">
+        <span className="text-slate-400">{label}</span>
+        <span className="text-slate-500 tabular-nums">
+          <span className="text-slate-200 font-medium">{num}</span>
+          <span> / {denom}</span>
+          <span className="ml-2 text-slate-400">({pct}%)</span>
+        </span>
+      </div>
+      <div className="h-2 rounded-full bg-slate-800 overflow-hidden">
+        <div className={`${accent} h-full transition-[width] duration-500`} style={{ width: `${clamped}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function CatalogList({ catalog }: { catalog: TrophyCatalogEntry[] }) {
+  // Group by game so the per-challenge list reads as a checklist
+  // organized by section header, not a flat soup.
+  const byGame = new Map<string, TrophyCatalogEntry[]>();
+  for (const c of catalog) {
+    const list = byGame.get(c.game) ?? [];
+    list.push(c);
+    byGame.set(c.game, list);
+  }
+  return (
+    <details className="rounded-md border border-slate-800 bg-slate-950/40">
+      <summary className="cursor-pointer select-none px-3 py-2 text-sm text-slate-300 hover:text-white">
+        Per-challenge breakdown — {catalog.length} total
+      </summary>
+      <div className="p-3 space-y-4">
+        {Array.from(byGame.entries()).map(([game, items]) => (
+          <div key={game}>
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-1.5">{game}</h3>
+            <ul className="space-y-1">
+              {items.map((c) => (
+                <li key={`${c.game}::${c.challengeName}`} className="flex items-center gap-2 text-sm">
+                  <GradeChip grade={c.bestGrade} />
+                  <Link
+                    href={challengeHref(c.game, c.challengeName)}
+                    className={c.attempted ? 'text-slate-200 hover:text-indigo-300 truncate' : 'text-slate-500 hover:text-slate-300 truncate italic'}
+                  >
+                    {c.challengeName}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}

--- a/src/lib/challenges-manifest.ts
+++ b/src/lib/challenges-manifest.ts
@@ -21,6 +21,13 @@ interface RawManifestChallenge {
   // runs into the /admin/pending review queue.
   minPlausibleFrames?: number;
   flagBelowFrames?: number;
+  // Per-challenge grade thresholds. Ordered SSS → SS → S → A → B by
+  // maxFrames; gradeForRun() walks the array and returns the first
+  // grade whose maxFrames the run's completionTimeFrames falls under.
+  grades?: {
+    by?: string;
+    thresholds?: { grade: string; maxFrames: number }[];
+  };
 }
 interface RawManifestGame {
   name: string;
@@ -42,6 +49,9 @@ export interface ChallengeMeta {
   // missing field never silently rejects legitimate runs).
   minPlausibleFrames?: number;
   flagBelowFrames?: number;
+  // Per-challenge grade thresholds (SSS → B by maxFrames).
+  // Undefined when the challenge defines no grading.
+  gradeThresholds?: { grade: string; maxFrames: number }[];
 }
 
 export interface GameMeta {
@@ -130,6 +140,10 @@ export function parseManifest(data: RawManifest): ParsedManifest {
     });
     for (const c of g.challenges) {
       if (!c || typeof c.name !== 'string') continue;
+      const rawThresholds = c.grades && Array.isArray(c.grades.thresholds) ? c.grades.thresholds : undefined;
+      const gradeThresholds = rawThresholds
+        ? rawThresholds.filter((t) => t && typeof t.grade === 'string' && typeof t.maxFrames === 'number')
+        : undefined;
       challenges.set(manifestKey(g.name, c.name), {
         game: g.name,
         challengeName: c.name,
@@ -137,6 +151,7 @@ export function parseManifest(data: RawManifest): ParsedManifest {
         difficulty: c.difficulty,
         minPlausibleFrames: typeof c.minPlausibleFrames === 'number' ? c.minPlausibleFrames : undefined,
         flagBelowFrames:    typeof c.flagBelowFrames    === 'number' ? c.flagBelowFrames    : undefined,
+        gradeThresholds:    gradeThresholds && gradeThresholds.length > 0 ? gradeThresholds : undefined,
       });
     }
   }

--- a/src/lib/grading.ts
+++ b/src/lib/grading.ts
@@ -1,0 +1,112 @@
+// Per-challenge grade derivation.
+//
+// The manifest defines a per-challenge `grades.thresholds` array
+// ordered SSS → SS → S → A → B by `maxFrames`. gradeForRun walks
+// the array and returns the FIRST grade whose maxFrames the player's
+// completionTimeFrames falls under. Stateless on purpose — no DB
+// column, no migration. Re-grade on every read so a manifest tweak
+// retroactively updates everyone's badges.
+//
+// All five grades are guaranteed present on every challenge in the
+// catalog (audited via challenges.json on 2026-05-04), so the only
+// nullable cases are: no thresholds at all (future challenge with
+// just a win/fail flag, no time grading) or the run has no
+// completionTimeFrames (score-only, no time recorded).
+
+export type Grade = 'SSS' | 'SS' | 'S' | 'A' | 'B';
+
+export const GRADE_ORDER: readonly Grade[] = ['SSS', 'SS', 'S', 'A', 'B'];
+
+export interface GradeThreshold {
+  grade: string;
+  maxFrames: number;
+}
+
+export function gradeForRun(
+  thresholds: GradeThreshold[] | undefined | null,
+  completionTimeFrames: number | null | undefined,
+): Grade | null {
+  if (!thresholds || thresholds.length === 0) return null;
+  if (completionTimeFrames == null || completionTimeFrames < 0) return null;
+
+  for (const t of thresholds) {
+    if (typeof t.maxFrames !== 'number') continue;
+    if (completionTimeFrames <= t.maxFrames) {
+      return GRADE_ORDER.includes(t.grade as Grade) ? (t.grade as Grade) : null;
+    }
+  }
+  return null;
+}
+
+// Tailwind classes for the grade chip. Color intent:
+//   SSS → bright gold (the "earned it" tier)
+//   SS  → silver / platinum
+//   S   → orange / bronze
+//   A   → cyan
+//   B   → muted slate
+const GRADE_STYLES: Record<Grade, string> = {
+  SSS: 'bg-amber-400/20  text-amber-200  border border-amber-400/50',
+  SS:  'bg-slate-200/20  text-slate-100  border border-slate-300/40',
+  S:   'bg-orange-500/20 text-orange-300 border border-orange-500/40',
+  A:   'bg-cyan-500/20   text-cyan-300   border border-cyan-500/40',
+  B:   'bg-slate-500/20  text-slate-400  border border-slate-500/40',
+};
+
+export function gradeChipClass(grade: Grade | null): string {
+  if (!grade) return 'bg-slate-700/40 text-slate-500 border border-slate-700';
+  return GRADE_STYLES[grade];
+}
+
+// Returns true when `a` is the same OR a strictly better grade than
+// `b` (e.g., bestGrade(SSS, SS) → true). Used by trophy aggregation
+// to pick the highest grade across multiple runs on the same
+// challenge. null counts as worst.
+export function gradeRank(g: Grade | null): number {
+  if (!g) return GRADE_ORDER.length;          // worse than B
+  return GRADE_ORDER.indexOf(g);              // SSS=0 → B=4
+}
+
+export function isBetterOrEqualGrade(a: Grade | null, b: Grade | null): boolean {
+  return gradeRank(a) <= gradeRank(b);
+}
+
+// Aggregate a player's grade tally across the catalog. Drives the
+// Trophy Room: count per grade + completion percentages.
+export interface TrophyStats {
+  totalChallenges: number;       // every challenge in the manifest
+  attemptedChallenges: number;   // user has at least one visible run
+  tally: Record<Grade, number>;  // best-grade-per-challenge counts
+  sssPct: number;                // sss / total (0-100)
+  ssOrBetterPct: number;         // (sss + ss) / total
+  attemptedPct: number;          // attempted / total
+}
+
+export function emptyTrophyStats(totalChallenges: number): TrophyStats {
+  return {
+    totalChallenges,
+    attemptedChallenges: 0,
+    tally: { SSS: 0, SS: 0, S: 0, A: 0, B: 0 },
+    sssPct: 0,
+    ssOrBetterPct: 0,
+    attemptedPct: 0,
+  };
+}
+
+// `bestGrades` = one entry per challenge the user has attempted, with
+// the best grade earned across the user's runs on that challenge.
+export function summarizeTrophies(
+  totalChallenges: number,
+  bestGrades: (Grade | null)[],
+): TrophyStats {
+  const stats = emptyTrophyStats(totalChallenges);
+  stats.attemptedChallenges = bestGrades.length;
+  for (const g of bestGrades) {
+    if (g) stats.tally[g] += 1;
+  }
+  if (totalChallenges > 0) {
+    stats.sssPct        = Math.round((stats.tally.SSS / totalChallenges) * 100);
+    stats.ssOrBetterPct = Math.round(((stats.tally.SSS + stats.tally.SS) / totalChallenges) * 100);
+    stats.attemptedPct  = Math.round((stats.attemptedChallenges / totalChallenges) * 100);
+  }
+  return stats;
+}

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,5 +1,6 @@
 import { prisma } from './db';
-import { getChallengesManifest, getGamesManifest } from './challenges-manifest';
+import { getChallengesManifest, getGamesManifest, manifestKey } from './challenges-manifest';
+import { gradeForRun, gradeRank, summarizeTrophies, type Grade, type TrophyStats } from './grading';
 
 // Resolve a user's effective avatar URL: if they uploaded a custom one
 // it lives at /api/users/<id>/avatar, otherwise we fall back to whatever
@@ -474,6 +475,14 @@ export interface UserProfile {
   createdAt: Date;
   totalRuns: number;
   challenges: UserProfileChallenge[];
+  // Trophy aggregation across the entire manifest. Drives the Trophy
+  // Room section: best-grade-per-challenge tally + completion %s +
+  // unattempted-challenges visibility.
+  trophies: TrophyStats;
+  // Manifest-driven full catalog the player can be measured against.
+  // Includes challenges they haven't attempted (bestGrade=null) so
+  // the Trophy Room can show empty rows as "go earn this".
+  catalog: TrophyCatalogEntry[];
 }
 
 // One row per (game, challengeName) the user has runs on.
@@ -488,6 +497,20 @@ export interface UserProfileChallenge {
     serverReceivedAt: Date;
   };
   rank: number | null;   // null if we couldn't determine; otherwise 1-based
+  // Best grade earned across this user's runs on this challenge.
+  // Null when the challenge has no grade thresholds in the manifest
+  // OR the user's best run has no completionTimeFrames.
+  bestGrade: Grade | null;
+}
+
+// One row per challenge in the manifest, regardless of whether the
+// user has attempted it. bestGrade is null for unattempted entries
+// so the Trophy Room can render them as "—" / dim rows.
+export interface TrophyCatalogEntry {
+  game: string;
+  challengeName: string;
+  bestGrade: Grade | null;
+  attempted: boolean;
 }
 
 // Build a UserProfile for /u/<userId>. Rank is computed by counting how many
@@ -524,22 +547,37 @@ export async function getUserProfile(userId: string): Promise<UserProfile | null
     },
   });
 
-  // Collapse to one row per (game, challengeName) — the first occurrence
-  // is already the user's best because the orderBy mirrors the leaderboard
-  // sort. Count attempts per challenge for the secondary stat.
-  const byChallenge = new Map<string, { best: typeof userRuns[number]; attempts: number }>();
+  // Collapse to one row per (game, challengeName). The orderBy already
+  // puts the best run first per challenge, so a Map insert-once keyed
+  // on (game, challengeName) yields the user's best automatically.
+  // We also walk EVERY run on each challenge to compute the best
+  // grade (which can outrank the best-time row when grading rewards
+  // a completion-time threshold the fastest run happens to miss —
+  // rare but possible if score weighting changes things later).
+  const byChallenge = new Map<string, {
+    best: typeof userRuns[number];
+    attempts: number;
+    bestGrade: Grade | null;
+  }>();
+  const manifest = await getChallengesManifest();
   for (const r of userRuns) {
     const key = `${r.game}::${r.challengeName}`;
+    const meta = manifest.get(manifestKey(r.game, r.challengeName));
+    const grade = gradeForRun(meta?.gradeThresholds, r.completionTimeFrames);
     const existing = byChallenge.get(key);
     if (!existing) {
-      byChallenge.set(key, { best: r, attempts: 1 });
+      byChallenge.set(key, { best: r, attempts: 1, bestGrade: grade });
     } else {
       existing.attempts += 1;
+      // Lower rank index = better grade (SSS=0 ... B=4); null is worse than B.
+      if (gradeRank(grade) < gradeRank(existing.bestGrade)) {
+        existing.bestGrade = grade;
+      }
     }
   }
 
   const challenges: UserProfileChallenge[] = await Promise.all(
-    Array.from(byChallenge.values()).map(async ({ best, attempts }) => {
+    Array.from(byChallenge.values()).map(async ({ best, attempts, bestGrade }) => {
       const top = await getChallengeLeaderboard(best.game, best.challengeName, 100);
       const idx = top.findIndex((entry) => entry.userId === userId);
       return {
@@ -553,6 +591,7 @@ export async function getUserProfile(userId: string): Promise<UserProfile | null
           serverReceivedAt: best.serverReceivedAt,
         },
         rank: idx >= 0 ? idx + 1 : null,
+        bestGrade,
       };
     }),
   );
@@ -562,6 +601,30 @@ export async function getUserProfile(userId: string): Promise<UserProfile | null
     return a.challengeName.localeCompare(b.challengeName);
   });
 
+  // Trophy catalog: union the user's attempted challenges with the
+  // full manifest so unattempted rows render as "—". Total count
+  // drives the completion percentages.
+  const attemptedByKey = new Map(challenges.map((c) => [`${c.game}::${c.challengeName}`, c]));
+  const catalog: TrophyCatalogEntry[] = [];
+  for (const meta of manifest.values()) {
+    const k = `${meta.game}::${meta.challengeName}`;
+    const att = attemptedByKey.get(k);
+    catalog.push({
+      game: meta.game,
+      challengeName: meta.challengeName,
+      bestGrade: att ? att.bestGrade : null,
+      attempted: !!att,
+    });
+  }
+  catalog.sort((a, b) => {
+    if (a.game !== b.game) return a.game.localeCompare(b.game);
+    return a.challengeName.localeCompare(b.challengeName);
+  });
+  const trophies = summarizeTrophies(
+    catalog.length,
+    challenges.map((c) => c.bestGrade),
+  );
+
   return {
     userId: user.id,
     name: user.name,
@@ -569,6 +632,8 @@ export async function getUserProfile(userId: string): Promise<UserProfile | null
     createdAt: user.createdAt,
     totalRuns: userRuns.length,
     challenges,
+    trophies,
+    catalog,
   };
 }
 

--- a/tests/grading.test.ts
+++ b/tests/grading.test.ts
@@ -1,0 +1,125 @@
+import {
+  gradeForRun,
+  gradeRank,
+  isBetterOrEqualGrade,
+  summarizeTrophies,
+  emptyTrophyStats,
+  GRADE_ORDER,
+  type Grade,
+} from '../src/lib/grading';
+
+const STD_THRESHOLDS = [
+  { grade: 'SSS', maxFrames: 1200 },
+  { grade: 'SS',  maxFrames: 2400 },
+  { grade: 'S',   maxFrames: 4800 },
+  { grade: 'A',   maxFrames: 9000 },
+  { grade: 'B',   maxFrames: 999999 },
+];
+
+describe('gradeForRun', () => {
+  test('returns the highest grade the player beat', () => {
+    expect(gradeForRun(STD_THRESHOLDS, 600)).toBe('SSS');
+    expect(gradeForRun(STD_THRESHOLDS, 1200)).toBe('SSS');
+    expect(gradeForRun(STD_THRESHOLDS, 1201)).toBe('SS');
+    expect(gradeForRun(STD_THRESHOLDS, 2400)).toBe('SS');
+    expect(gradeForRun(STD_THRESHOLDS, 4801)).toBe('A');
+    expect(gradeForRun(STD_THRESHOLDS, 9000)).toBe('A');
+    expect(gradeForRun(STD_THRESHOLDS, 9001)).toBe('B');
+  });
+
+  test('null when run has no completionTimeFrames', () => {
+    expect(gradeForRun(STD_THRESHOLDS, null)).toBeNull();
+    expect(gradeForRun(STD_THRESHOLDS, undefined)).toBeNull();
+  });
+
+  test('null when challenge has no thresholds', () => {
+    expect(gradeForRun(undefined, 100)).toBeNull();
+    expect(gradeForRun(null, 100)).toBeNull();
+    expect(gradeForRun([], 100)).toBeNull();
+  });
+
+  test('null on negative completionTimeFrames', () => {
+    expect(gradeForRun(STD_THRESHOLDS, -1)).toBeNull();
+  });
+
+  test('skips thresholds with non-numeric maxFrames', () => {
+    const malformed = [
+      { grade: 'SSS', maxFrames: 'fast' as unknown as number },
+      { grade: 'SS',  maxFrames: 2400 },
+    ];
+    expect(gradeForRun(malformed, 1000)).toBe('SS');
+  });
+
+  test('null on unknown grade strings (forward-compat: ignored, not thrown)', () => {
+    const unknown = [
+      { grade: 'GOD',  maxFrames: 100 },
+      { grade: 'SSS',  maxFrames: 1200 },
+    ];
+    // Player beat the GOD threshold, but it's not a known grade.
+    expect(gradeForRun(unknown, 50)).toBeNull();
+  });
+});
+
+describe('gradeRank + isBetterOrEqualGrade', () => {
+  test('SSS ranks highest, B ranks lowest, null is worst', () => {
+    expect(gradeRank('SSS')).toBe(0);
+    expect(gradeRank('SS')).toBe(1);
+    expect(gradeRank('B')).toBe(4);
+    expect(gradeRank(null)).toBe(GRADE_ORDER.length);
+  });
+
+  test('isBetterOrEqualGrade compares correctly', () => {
+    expect(isBetterOrEqualGrade('SSS', 'SS')).toBe(true);
+    expect(isBetterOrEqualGrade('SS', 'SSS')).toBe(false);
+    expect(isBetterOrEqualGrade('A', 'A')).toBe(true);
+    expect(isBetterOrEqualGrade('B', null)).toBe(true);
+    expect(isBetterOrEqualGrade(null, 'B')).toBe(false);
+  });
+});
+
+describe('summarizeTrophies', () => {
+  test('all-empty player gets zero everything', () => {
+    const stats = summarizeTrophies(25, []);
+    expect(stats.totalChallenges).toBe(25);
+    expect(stats.attemptedChallenges).toBe(0);
+    expect(stats.tally.SSS).toBe(0);
+    expect(stats.sssPct).toBe(0);
+    expect(stats.attemptedPct).toBe(0);
+  });
+
+  test('per-grade tally + percentages', () => {
+    const grades: (Grade | null)[] = ['SSS', 'SSS', 'SS', 'S', 'S', 'S', 'A', 'B'];
+    const stats = summarizeTrophies(25, grades);
+    expect(stats.attemptedChallenges).toBe(8);
+    expect(stats.tally).toEqual({ SSS: 2, SS: 1, S: 3, A: 1, B: 1 });
+    expect(stats.sssPct).toBe(8);                 // 2/25 = 8%
+    expect(stats.ssOrBetterPct).toBe(12);         // 3/25 = 12%
+    expect(stats.attemptedPct).toBe(32);          // 8/25 = 32%
+  });
+
+  test('null grades count as attempts but contribute to no tally', () => {
+    const stats = summarizeTrophies(10, [null, null, 'SSS']);
+    expect(stats.attemptedChallenges).toBe(3);
+    expect(stats.tally.SSS).toBe(1);
+    expect(stats.sssPct).toBe(10);                // 1/10
+  });
+
+  test('division-by-zero protection when totalChallenges is 0', () => {
+    const stats = summarizeTrophies(0, []);
+    expect(stats.sssPct).toBe(0);
+    expect(stats.attemptedPct).toBe(0);
+  });
+});
+
+describe('emptyTrophyStats', () => {
+  test('reproducible empty shape', () => {
+    expect(emptyTrophyStats(25)).toEqual({
+      totalChallenges: 25,
+      attemptedChallenges: 0,
+      tally: { SSS: 0, SS: 0, S: 0, A: 0, B: 0 },
+      sssPct: 0,
+      ssOrBetterPct: 0,
+      attemptedPct: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
The manifest's per-challenge \`grades.thresholds\` (SSS → B by maxFrames) finally drive UI. Two surfaces:

| Surface | What |
|---|---|
| **Grade chips** on every leaderboard row | New \`Grade\` column on \`/leaderboards/c/[game]/[challenge]\`, \`/me\`, and \`/u/[userId]\` tables. Color-coded (SSS=gold, SS=silver, S=bronze, A=cyan, B=slate). |
| **Trophy Room** on profile pages | New section above the per-challenge table on \`/me\` and \`/u/[userId]\`. Top bars show SSS%, SS-or-better%, attempted% across the whole catalog. Tally row shows per-grade chip × count. Collapsible per-challenge breakdown grouped by game lists every challenge with the user's best grade or "—" for unattempted. |

## Approach
- Stateless grading: \`gradeForRun(thresholds, frames)\` walks the manifest's threshold array and returns the highest grade the player beat. No DB column, no migration, manifest tweaks retroactively re-grade everyone.
- Single \`getChallengesManifest()\` fetch in \`getUserProfile\` instead of N+1.
- Trophy Room is pure presentational — caller computes \`trophies\` + \`catalog\` once.

## Icons
None yet. Text chips are the placeholder. Once \`assets/grades/{sss,ss,s,a,b}.png\` lands in the assets repo, swap-in is one line in \`GradeChip.tsx\`.

## Test plan
- [x] typecheck clean
- [x] 75/75 tests passing (62 → 75, thirteen new grading cases)
- [x] \`npm run build\` green
- [ ] After deploy: every leaderboard row shows a Grade column; \`/me\` shows the Trophy Room with stats matching `getChallengeLeaderboard` + manifest data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)