### PR TITLE
chore(releases): point home + releases-page links at flawlessnes-releases

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,7 +52,7 @@ function Hero() {
       </p>
       <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
         <a
-          href="https://github.com/heliacode/RetroChallenges/releases/latest"
+          href="https://github.com/heliacode/flawlessnes-releases/releases/latest"
           className="inline-flex items-center gap-2 rounded-md bg-indigo-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 hover:bg-indigo-600 transition-colors"
         >
           Download for Windows

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { headers } from 'next/headers';
 import { CatalogView } from '@/components/CatalogView';
+import { getLatestWindowsDownloadUrl } from '@/lib/releases';
 
 // Skip build-time pre-render — we don't have a DB at build time on Railway,
 // and we need to read the request host to decide what to render.
@@ -21,16 +22,20 @@ export default async function HomePage() {
   if (LEGACY_CATALOG_HOSTS.has(hostname)) {
     return <CatalogView />;
   }
-  return <LandingPage />;
+  // Resolve the latest stable Windows installer URL at render time so
+  // the Download CTA deep-links straight to the .exe — bypasses the
+  // cryptic-for-end-users GitHub releases page.
+  const downloadUrl = await getLatestWindowsDownloadUrl();
+  return <LandingPage downloadUrl={downloadUrl} />;
 }
 
 // ---------------------------------------------------------------------------
 // Landing page (flawlessnes.com)
 // ---------------------------------------------------------------------------
-function LandingPage() {
+function LandingPage({ downloadUrl }: { downloadUrl: string }) {
   return (
     <div className="space-y-16">
-      <Hero />
+      <Hero downloadUrl={downloadUrl} />
       <Features />
       <FeaturedCreator />
       <Creators />
@@ -38,7 +43,7 @@ function LandingPage() {
   );
 }
 
-function Hero() {
+function Hero({ downloadUrl }: { downloadUrl: string }) {
   return (
     <section className="text-center pt-8">
       <h1 className="font-display text-4xl sm:text-5xl font-bold text-white tracking-tight">
@@ -52,7 +57,7 @@ function Hero() {
       </p>
       <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
         <a
-          href="https://github.com/heliacode/flawlessnes-releases/releases/latest"
+          href={downloadUrl}
           className="inline-flex items-center gap-2 rounded-md bg-indigo-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 hover:bg-indigo-600 transition-colors"
         >
           Download for Windows

--- a/src/app/releases/page.tsx
+++ b/src/app/releases/page.tsx
@@ -33,7 +33,7 @@ export default async function ReleasesPage() {
         <p className="text-slate-400">
           Couldn&rsquo;t reach the GitHub releases API. Try again in a few minutes, or browse{' '}
           <a
-            href="https://github.com/heliacode/RetroChallenges/releases"
+            href="https://github.com/heliacode/flawlessnes-releases/releases"
             target="_blank"
             rel="noopener noreferrer"
             className="text-indigo-300 hover:text-indigo-200 underline"

--- a/src/lib/releases.ts
+++ b/src/lib/releases.ts
@@ -6,8 +6,12 @@
 // has a 60-req/hr rate limit for unauthed requests so being conservative
 // matters.
 
+// Public releases repo. The source repo (heliacode/RetroChallenges) is
+// private; built installers are pushed to flawlessnes-releases by the
+// manual_release.yml workflow so anonymous users (and this page) can
+// fetch without authentication.
 const RELEASES_URL =
-  'https://api.github.com/repos/heliacode/RetroChallenges/releases?per_page=20';
+  'https://api.github.com/repos/heliacode/flawlessnes-releases/releases?per_page=20';
 const REVALIDATE_SECONDS = 600; // 10 min
 
 export interface ReleaseAsset {

--- a/src/lib/releases.ts
+++ b/src/lib/releases.ts
@@ -49,6 +49,32 @@ interface RawRelease {
   assets: RawAsset[];
 }
 
+// Resolves the direct browser-download URL for the latest stable
+// Windows installer, so the home-page CTA can deep-link straight to
+// the .exe instead of dumping users on a GitHub releases page (which
+// is cryptic and forces them to pick a file). Skips drafts and
+// prereleases. Falls back to /releases on this site if the API is
+// unreachable or no .exe asset is found.
+//
+// Pattern match is intentionally loose — electron-builder emits
+// `RetroChallenges Setup <version>.exe` (with spaces, sometimes dots
+// or dashes between version segments). We match any release asset
+// whose filename ends in `.exe`. If multiple .exe assets ship per
+// release someday, we'd refine; for now, one .exe = the Setup
+// installer.
+export async function getLatestWindowsDownloadUrl(): Promise<string> {
+  const FALLBACK = '/releases';
+  try {
+    const releases = await getReleases();
+    const stable = releases.find((r) => !r.draft && !r.prerelease);
+    if (!stable) return FALLBACK;
+    const exe = stable.assets.find((a) => a.name.toLowerCase().endsWith('.exe'));
+    return exe ? exe.browser_download_url : FALLBACK;
+  } catch {
+    return FALLBACK;
+  }
+}
+
 export async function getReleases(): Promise<Release[]> {
   try {
     const res = await fetch(RELEASES_URL, {


### PR DESCRIPTION
Two CTAs still went to the private source repo and 404'd for anonymous users. Now point at the public flawlessnes-releases repo, matching the API fetch URL in PR #36.