### PR TITLE
FlawlessNES: rank no-hit challenges by fewest hits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ playwright/.cache/
 # Prisma
 prisma/migrations/dev.db
 prisma/migrations/dev.db-journal
+
+# prove-it demo artifacts (ephemeral)
+prove-it/
+.env.local

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { prisma } from '@/lib/db';
 import { verifySubmissionSecret } from '@/lib/auth';
 import { isBetterRun, getChallengeLeaderboard, challengeHref } from '@/lib/leaderboard';
+import { getChallengesManifest, isFlawlessCategory, manifestKey } from '@/lib/challenges-manifest';
 import { notifyDiscordTopPlacement } from '@/lib/discord';
 import { rateLimit } from '@/lib/rate-limit';
 
@@ -128,6 +129,13 @@ export async function POST(req: NextRequest) {
       },
     });
 
+    // FlawlessNES challenges rank score-first (fewest hits); everything
+    // else ranks time-first. Drives both the prior-best sort and the PB
+    // comparison below so the celebration matches the public board.
+    const flawless = isFlawlessCategory(
+      (await getChallengesManifest()).get(manifestKey(s.game, s.challengeName))?.category,
+    );
+
     // Look up the user's previous best on this challenge BEFORE the
     // insert so the new run isn't compared against itself. Same sort
     // order the public leaderboard uses. Pending runs aren't counted —
@@ -140,10 +148,15 @@ export async function POST(req: NextRequest) {
         hiddenAt: null,
         pendingReview: false,
       },
-      orderBy: [
-        { score: { sort: 'desc', nulls: 'last' } },
-        { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
-      ],
+      orderBy: flawless
+        ? [
+            { score: { sort: 'desc', nulls: 'last' } },
+            { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
+          ]
+        : [
+            { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
+            { score: { sort: 'desc', nulls: 'last' } },
+          ],
       select: { score: true, completionTimeFrames: true },
     });
 
@@ -169,6 +182,7 @@ export async function POST(req: NextRequest) {
         isBetterRun(
           { score: run.score, completionTimeFrames: run.completionTimeFrames },
           priorBestRow,
+          flawless,
         ));
 
     if (!pendingReview) {

--- a/src/app/leaderboards/c/[game]/[challenge]/page.tsx
+++ b/src/app/leaderboards/c/[game]/[challenge]/page.tsx
@@ -13,8 +13,13 @@ import {
   type LeaderboardWindow,
   type LeaderboardView,
 } from '@/lib/leaderboard';
-import { getChallengesManifest, manifestKey } from '@/lib/challenges-manifest';
-import { gradeForRun } from '@/lib/grading';
+import { getChallengesManifest, isFlawlessCategory, manifestKey } from '@/lib/challenges-manifest';
+import {
+  gradeForRun,
+  flawlessRankForScore,
+  flawlessHitsForScore,
+  flawlessRankChipClass,
+} from '@/lib/grading';
 import { GradeChip } from '@/components/GradeChip';
 
 export const dynamic = 'force-dynamic';
@@ -53,7 +58,11 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
     getChallengesManifest(),
   ]);
   // Grade thresholds for THIS challenge (looked up once, reused per row).
-  const gradeThresholds = manifest.get(manifestKey(game, challengeName))?.gradeThresholds;
+  const challengeMeta = manifest.get(manifestKey(game, challengeName));
+  const gradeThresholds = challengeMeta?.gradeThresholds;
+  // FlawlessNES challenges rank by hits (score), not time — different
+  // columns (Rank / Hits) and a no-time-grade chip.
+  const flawless = isFlawlessCategory(challengeMeta?.category);
   const meId = session?.user?.id ?? null;
   const firstEverUserId = firstEverCompleter?.userId ?? null;
 
@@ -82,9 +91,11 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
               <tr className="text-left text-xs uppercase tracking-wider text-slate-500 border-b border-slate-700">
                 <th className="py-2 pr-2 w-12">#</th>
                 <th className="py-2 pr-2">Player</th>
+                {flawless && <th className="py-2 pr-2 text-right">Rank</th>}
+                {flawless && <th className="py-2 pr-2 text-right">Hits</th>}
                 <th className="py-2 pr-2 text-right">Score</th>
                 <th className="py-2 pr-2 text-right">Time</th>
-                <th className="py-2 pr-2 text-right">Grade</th>
+                {!flawless && <th className="py-2 pr-2 text-right">Grade</th>}
                 <th className="py-2 pr-2 text-right hidden sm:table-cell">Submitted</th>
               </tr>
             </thead>
@@ -136,15 +147,27 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
                         )}
                       </Link>
                     </td>
+                    {flawless && (
+                      <td className="py-2 pr-2 text-right">
+                        <FlawlessRankChip score={e.score} />
+                      </td>
+                    )}
+                    {flawless && (
+                      <td className="py-2 pr-2 text-right font-mono text-slate-200 tabular-nums">
+                        {flawlessHitsForScore(e.score) ?? '—'}
+                      </td>
+                    )}
                     <td className="py-2 pr-2 text-right font-mono text-slate-200">
                       {e.score != null ? e.score.toLocaleString() : '—'}
                     </td>
                     <td className="py-2 pr-2 text-right font-mono text-slate-200">
                       {formatFrames(e.completionTimeFrames)}
                     </td>
-                    <td className="py-2 pr-2 text-right">
-                      <GradeChip grade={gradeForRun(gradeThresholds, e.completionTimeFrames)} size="md" />
-                    </td>
+                    {!flawless && (
+                      <td className="py-2 pr-2 text-right">
+                        <GradeChip grade={gradeForRun(gradeThresholds, e.completionTimeFrames)} size="md" />
+                      </td>
+                    )}
                     <td className="py-2 pr-2 text-right text-xs text-slate-500 hidden sm:table-cell">
                       {new Date(e.serverReceivedAt).toLocaleDateString()}
                     </td>
@@ -156,6 +179,20 @@ export default async function ChallengeLeaderboardPage({ params, searchParams }:
         </div>
       )}
     </div>
+  );
+}
+
+// Flawless/A/B/C/D pill derived from the submitted score. Mirrors GradeChip
+// but uses the FlawlessNES rank palette (Flawless = gold).
+function FlawlessRankChip({ score }: { score: number | null }) {
+  const rank = flawlessRankForScore(score);
+  return (
+    <span
+      className={`inline-flex items-center justify-center rounded-md font-bold tracking-wider px-2.5 py-1 text-xs ${flawlessRankChipClass(rank)}`}
+      title={rank ? `Rank ${rank}` : 'No rank'}
+    >
+      {rank ?? '—'}
+    </span>
   );
 }
 

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -7,11 +7,14 @@ import {
   gameHref,
   getOverallStats,
   getRecentRuns,
+  listFlawlessSummaries,
   listGames,
   userProfileHref,
+  type ChallengeSummary,
   type GameSummary,
   type RecentRunEntry,
 } from '@/lib/leaderboard';
+import { flawlessRankForScore, flawlessRankChipClass } from '@/lib/grading';
 import { AutoRefresh } from '@/components/AutoRefresh';
 
 // Hero + game-tile grid + recent-activity feed. Rendered by both the
@@ -23,9 +26,10 @@ import { AutoRefresh } from '@/components/AutoRefresh';
 // to pick something to play), recent activity is the addictive scroll
 // underneath. AutoRefresh re-pulls every 30s either way.
 export async function CatalogView() {
-  const [stats, games, recent] = await Promise.all([
+  const [stats, games, flawless, recent] = await Promise.all([
     getOverallStats(),
     listGames(),
+    listFlawlessSummaries(),
     getRecentRuns(20),
   ]);
 
@@ -33,6 +37,8 @@ export async function CatalogView() {
     <div className="space-y-10">
       <AutoRefresh intervalMs={30000} />
       <Hero stats={stats} />
+
+      {flawless.length > 0 && <FlawlessSection items={flawless} />}
 
       {games.length === 0 ? (
         <section className="rounded-lg border border-dashed border-slate-700 p-8 text-center">
@@ -47,6 +53,66 @@ export async function CatalogView() {
         </>
       )}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// FlawlessNES — its own top-level section. These challenges are no-hit runs
+// ranked by fewest hits (Flawless → D), distinct from the time-ranked
+// RetroChallenges below.
+// ---------------------------------------------------------------------------
+function FlawlessSection({ items }: { items: ChallengeSummary[] }) {
+  return (
+    <section>
+      <div className="mb-3 flex items-baseline gap-2">
+        <h2 className="font-display text-xl font-semibold text-amber-200">FlawlessNES</h2>
+        <span className="text-xs font-normal text-slate-500">
+          no-damage runs · ranked by fewest hits
+        </span>
+      </div>
+      <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((c) => (
+          <li key={`${c.game}::${c.challengeName}`}>
+            <FlawlessCard summary={c} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function FlawlessCard({ summary }: { summary: ChallengeSummary }) {
+  const top = summary.topRun;
+  const rank = top ? flawlessRankForScore(top.score) : null;
+  return (
+    <Link
+      href={challengeHref(summary.game, summary.challengeName)}
+      className="group block rounded-lg border border-amber-500/20 bg-slate-900 p-4 transition-colors hover:border-amber-400/60 hover:bg-slate-800"
+    >
+      <div className="min-w-0">
+        <div className="font-medium text-slate-100 truncate">{summary.challengeName}</div>
+        <div className="text-xs text-slate-500 mt-0.5">
+          {summary.game}
+          <span className="mx-1.5">&middot;</span>
+          {summary.playerCount} player{summary.playerCount === 1 ? '' : 's'}
+        </div>
+      </div>
+      {top ? (
+        <div className="mt-3 flex items-center gap-2 rounded-md bg-slate-925 px-2.5 py-2 text-sm">
+          <span className="font-mono text-amber-300" aria-label="Rank 1">#1</span>
+          <span className="text-slate-200 truncate flex-1">{top.userName}</span>
+          <span
+            className={`inline-flex items-center justify-center rounded-md px-2 py-0.5 text-[11px] font-bold tracking-wider ${flawlessRankChipClass(rank)}`}
+          >
+            {rank ?? '—'}
+          </span>
+        </div>
+      ) : (
+        <div className="mt-3 flex h-9 items-center justify-center gap-2 rounded-md border border-dashed border-slate-700 px-2.5 text-xs text-slate-500">
+          Be the first to go flawless
+        </div>
+      )}
+    </Link>
   );
 }
 

--- a/src/lib/challenges-manifest.ts
+++ b/src/lib/challenges-manifest.ts
@@ -8,7 +8,11 @@
 // module scope with a TTL, plus serve stale on failure so a flaky
 // GitHub raw response doesn't break the page.
 
+// Defaults to the assets repo's main branch. Overridable via MANIFEST_URL
+// for local development / testing against an un-pushed manifest (e.g. a
+// locally-served challenges.json).
 const MANIFEST_URL =
+  process.env.MANIFEST_URL ??
   'https://raw.githubusercontent.com/heliacode/retrochallenges-assets/refs/heads/main/challenges.json';
 const TTL_MS = 5 * 60 * 1000; // 5 minutes — matches Next.js fetch revalidate hint below
 
@@ -163,19 +167,36 @@ export function parseManifest(data: RawManifest): ParsedManifest {
 // duplicated here so the leaderboard renders consistently even if the
 // manifest fetch fails or a new category appears upstream).
 // ---------------------------------------------------------------------------
-export const CATEGORY_ORDER: readonly string[] = ['boss', 'speedrun', 'survival', 'score'];
+// FlawlessNES is its own challenge family (no-hit runs, ranked by fewest
+// hits, not time). Listed first so it leads the per-game category sections.
+export const FLAWLESS_CATEGORY = 'flawlessnes';
+
+export const CATEGORY_ORDER: readonly string[] = [FLAWLESS_CATEGORY, 'boss', 'speedrun', 'survival', 'score'];
 
 export const CATEGORY_LABELS: Record<string, string> = {
-  boss:     'Boss Fights',
-  speedrun: 'Speedruns',
-  survival: 'Survival',
-  score:    'Score Targets',
-  other:    'Other',
+  flawlessnes: 'FlawlessNES — No Damage',
+  boss:        'Boss Fights',
+  speedrun:    'Speedruns',
+  survival:    'Survival',
+  score:       'Score Targets',
+  other:       'Other',
 };
 
 export function categoryLabel(category: string | undefined): string {
   if (!category) return CATEGORY_LABELS.other;
   return CATEGORY_LABELS[category] ?? category;
+}
+
+// FlawlessNES challenges rank by score (fewest hits) instead of time, and
+// render rank labels (Flawless/A/B/C/D) rather than the SSS–B time grade.
+// Everything keys off this single category check.
+export function isFlawlessCategory(category: string | undefined | null): boolean {
+  return category === FLAWLESS_CATEGORY;
+}
+
+export async function isFlawlessChallenge(game: string, challengeName: string): Promise<boolean> {
+  const map = await getChallengesManifest();
+  return isFlawlessCategory(map.get(manifestKey(game, challengeName))?.category);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/grading.ts
+++ b/src/lib/grading.ts
@@ -57,6 +57,65 @@ export function gradeChipClass(grade: Grade | null): string {
   return GRADE_STYLES[grade];
 }
 
+// ---------------------------------------------------------------------------
+// FlawlessNES ranking
+//
+// The FlawlessNES challenge family scores by HITS TAKEN, not time. Every
+// FlawlessNES challenge shares ONE fixed table (also computed in the
+// challenge .lua so the in-game HUD and the board agree exactly):
+//
+//   Hits  Rank      Score
+//   0     Flawless  5000
+//   1     A         3500
+//   2     B         2750
+//   3     C         2000
+//   4     D         1250
+//   5+    D         round(1250 * 0.85^(hits-4))   (geometric tail, never 0)
+//
+// The desktop client submits the SCORE, which is strictly monotonic-
+// decreasing in hits — so the board ranks by score DESC and recovers both
+// the rank label and the hit count from the score alone. No DB column for
+// hits is needed, and the existing (game, challengeName, score DESC,
+// completionTimeFrames ASC) index serves the ranking directly.
+export type FlawlessRank = 'Flawless' | 'A' | 'B' | 'C' | 'D';
+
+export const FLAWLESS_RANK_ORDER: readonly FlawlessRank[] = ['Flawless', 'A', 'B', 'C', 'D'];
+
+// Rank label from the submitted score (cutoffs straight off the table).
+export function flawlessRankForScore(score: number | null | undefined): FlawlessRank | null {
+  if (score == null) return null;
+  if (score >= 5000) return 'Flawless';
+  if (score >= 3500) return 'A';
+  if (score >= 2750) return 'B';
+  if (score >= 2000) return 'C';
+  return 'D';
+}
+
+// Exact inverse of the scoring table: recover hits from the score.
+// 0..4 hits live in the linear top band (score = 3500 - 750*(h-1));
+// 5+ hits invert the geometric tail. Returns null when there's no score.
+export function flawlessHitsForScore(score: number | null | undefined): number | null {
+  if (score == null) return null;
+  if (score >= 5000) return 0;
+  if (score >= 1250) return Math.round((3500 - score) / 750) + 1; // h = 1..4
+  // score = 1250 * 0.85^(h-4)  ->  h = 4 + ln(score/1250)/ln(0.85)
+  const h = 4 + Math.log(score / 1250) / Math.log(0.85);
+  return Math.max(5, Math.round(h));
+}
+
+const FLAWLESS_RANK_STYLES: Record<FlawlessRank, string> = {
+  Flawless: 'bg-amber-400/20   text-amber-200   border border-amber-400/50',
+  A:        'bg-emerald-500/20 text-emerald-300 border border-emerald-500/40',
+  B:        'bg-cyan-500/20    text-cyan-300    border border-cyan-500/40',
+  C:        'bg-indigo-500/20  text-indigo-300  border border-indigo-500/40',
+  D:        'bg-slate-500/20   text-slate-400   border border-slate-500/40',
+};
+
+export function flawlessRankChipClass(rank: FlawlessRank | null): string {
+  if (!rank) return 'bg-slate-700/40 text-slate-500 border border-slate-700';
+  return FLAWLESS_RANK_STYLES[rank];
+}
+
 // Returns true when `a` is the same OR a strictly better grade than
 // `b` (e.g., bestGrade(SSS, SS) → true). Used by trophy aggregation
 // to pick the highest grade across multiple runs on the same

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,6 +1,51 @@
 import { prisma } from './db';
-import { getChallengesManifest, getGamesManifest, manifestKey } from './challenges-manifest';
+import {
+  getChallengesManifest,
+  getGamesManifest,
+  isFlawlessCategory,
+  manifestKey,
+} from './challenges-manifest';
 import { gradeForRun, gradeRank, summarizeTrophies, type Grade, type TrophyStats } from './grading';
+
+// Ranking is normally time-first (fastest clear wins, score breaks ties).
+// FlawlessNES challenges invert this: score-first (fewest hits = highest
+// score), time breaks ties. `scoreFirst` threads that choice through the
+// Prisma orderBy and the JS comparators so both axes stay consistent.
+type RunSortRow = {
+  score: number | null;
+  completionTimeFrames: number | null;
+  serverReceivedAt?: Date;
+};
+
+// Prisma orderBy fragment honoring the ranking axis. `leadUserId` prepends
+// the userId sort the DISTINCT ON (best-per-user) query requires.
+function runOrderBy(scoreFirst: boolean, leadUserId = false) {
+  const byScore = { score: { sort: 'desc', nulls: 'last' } } as const;
+  const byTime = { completionTimeFrames: { sort: 'asc', nulls: 'last' } } as const;
+  const byRecv = { serverReceivedAt: 'asc' } as const;
+  const core = scoreFirst ? [byScore, byTime, byRecv] : [byTime, byScore, byRecv];
+  return leadUserId ? [{ userId: 'asc' } as const, ...core] : core;
+}
+
+// JS comparator matching runOrderBy — used to re-sort after a DISTINCT ON
+// query (which returns userId order) and anywhere we sort in memory.
+function compareRuns(a: RunSortRow, b: RunSortRow, scoreFirst: boolean): number {
+  const as = a.score ?? -Infinity;
+  const bs = b.score ?? -Infinity;
+  const at = a.completionTimeFrames ?? Infinity;
+  const bt = b.completionTimeFrames ?? Infinity;
+  if (scoreFirst) {
+    if (as !== bs) return bs - as;
+    if (at !== bt) return at - bt;
+  } else {
+    if (at !== bt) return at - bt;
+    if (as !== bs) return bs - as;
+  }
+  if (a.serverReceivedAt && b.serverReceivedAt) {
+    return a.serverReceivedAt.getTime() - b.serverReceivedAt.getTime();
+  }
+  return 0;
+}
 
 // Resolve a user's effective avatar URL: if they uploaded a custom one
 // it lives at /api/users/<id>/avatar, otherwise we fall back to whatever
@@ -73,6 +118,10 @@ export async function getChallengeLeaderboard(
   view: LeaderboardView = 'best',
 ): Promise<LeaderboardEntry[]> {
   const since = windowSince(window);
+  // FlawlessNES challenges rank score-first (fewest hits); everything else
+  // ranks time-first. Manifest fetch is cached, so this is ~free.
+  const manifest = await getChallengesManifest();
+  const scoreFirst = isFlawlessCategory(manifest.get(manifestKey(game, challengeName))?.category);
   const baseWhere = {
     game,
     challengeName,
@@ -110,31 +159,15 @@ export async function getChallengeLeaderboard(
     const dedup = await prisma.run.findMany({
       where: baseWhere,
       distinct: ['userId'],
-      orderBy: [
-        { userId: 'asc' },
-        { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
-        { score: { sort: 'desc', nulls: 'last' } },
-      ],
+      orderBy: runOrderBy(scoreFirst, true),
       select: baseSelect,
     });
-    dedup.sort((a, b) => {
-      const at = a.completionTimeFrames ?? Infinity;
-      const bt = b.completionTimeFrames ?? Infinity;
-      if (at !== bt) return at - bt;
-      const as = a.score ?? -Infinity;
-      const bs = b.score ?? -Infinity;
-      if (as !== bs) return bs - as;
-      return a.serverReceivedAt.getTime() - b.serverReceivedAt.getTime();
-    });
+    dedup.sort((a, b) => compareRuns(a, b, scoreFirst));
     rows = dedup.slice(0, limit);
   } else {
     rows = await prisma.run.findMany({
       where: baseWhere,
-      orderBy: [
-        { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
-        { score: { sort: 'desc', nulls: 'last' } },
-        { serverReceivedAt: 'asc' },
-      ],
+      orderBy: runOrderBy(scoreFirst),
       take: limit,
       select: baseSelect,
     });
@@ -253,6 +286,20 @@ export async function listChallengeSummaries(game?: string): Promise<ChallengeSu
     a.game === b.game
       ? a.challengeName.localeCompare(b.challengeName)
       : a.game.localeCompare(b.game),
+  );
+}
+
+// FlawlessNES challenges across every game, for the catalog's dedicated
+// top-level section. Reuses listChallengeSummaries (so manifest-only
+// challenges with no runs still surface) and filters to the flawlessnes
+// category from the manifest.
+export async function listFlawlessSummaries(): Promise<ChallengeSummary[]> {
+  const [summaries, manifest] = await Promise.all([
+    listChallengeSummaries(),
+    getChallengesManifest(),
+  ]);
+  return summaries.filter((s) =>
+    isFlawlessCategory(manifest.get(manifestKey(s.game, s.challengeName))?.category),
   );
 }
 
@@ -390,6 +437,9 @@ export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
     },
   });
 
+  // Manifest (cached) drives the per-challenge ranking axis for the PB badge.
+  const manifest = await getChallengesManifest();
+
   // Per-row enrichment: three independent queries fanned out in parallel
   // for each of the (small) recent set. N+1 with N ≤ ~20 — fine at our
   // scale; revisit with a window-function aggregation when this hits the
@@ -397,6 +447,7 @@ export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
   return Promise.all(
     rows.map(async (r): Promise<RecentRunEntry> => {
       const streakSince = new Date(r.serverReceivedAt.getTime() - STREAK_WINDOW_MS);
+      const scoreFirst = isFlawlessCategory(manifest.get(manifestKey(r.game, r.challengeName))?.category);
 
       const [firstEver, priorBetter, streakCount] = await Promise.all([
         // Was this the first-ever submission on this (game, challenge)?
@@ -422,10 +473,7 @@ export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
             pendingReview: false,
             serverReceivedAt: { lt: r.serverReceivedAt },
           },
-          orderBy: [
-            { completionTimeFrames: { sort: 'asc', nulls: 'last' } },
-            { score: { sort: 'desc', nulls: 'last' } },
-          ],
+          orderBy: runOrderBy(scoreFirst),
           select: { score: true, completionTimeFrames: true },
         }),
         // How many runs has this user had on this challenge within the last
@@ -445,6 +493,7 @@ export async function getRecentRuns(limit = 10): Promise<RecentRunEntry[]> {
       const personalBest = !priorBetter || isBetterRun(
         { score: r.score, completionTimeFrames: r.completionTimeFrames },
         priorBetter,
+        scoreFirst,
       );
 
       return {
@@ -563,12 +612,18 @@ export async function getUserProfile(userId: string): Promise<UserProfile | null
   for (const r of userRuns) {
     const key = `${r.game}::${r.challengeName}`;
     const meta = manifest.get(manifestKey(r.game, r.challengeName));
+    const scoreFirst = isFlawlessCategory(meta?.category);
     const grade = gradeForRun(meta?.gradeThresholds, r.completionTimeFrames);
     const existing = byChallenge.get(key);
     if (!existing) {
       byChallenge.set(key, { best: r, attempts: 1, bestGrade: grade });
     } else {
       existing.attempts += 1;
+      // userRuns is ordered time-first, which is wrong for FlawlessNES —
+      // pick the best per challenge explicitly under its ranking axis.
+      if (isBetterRun(r, existing.best, scoreFirst)) {
+        existing.best = r;
+      }
       // Lower rank index = better grade (SSS=0 ... B=4); null is worse than B.
       if (gradeRank(grade) < gradeRank(existing.bestGrade)) {
         existing.bestGrade = grade;
@@ -684,17 +739,20 @@ export interface RunMetric {
   score: number | null;
   completionTimeFrames: number | null;
 }
-export function isBetterRun(a: RunMetric, b: RunMetric): boolean {
-  // Time-first ranking: every shipping challenge is a speedrun (the
-  // win predicate is a state — boss dead, score reached, etc. — and
-  // the leaderboard cares about how fast you got there). Score is
-  // only used as a tie-break so score-only legacy challenges still
-  // sort sanely.
+// Returns true when `a` is strictly better than `b`. Default ranking is
+// time-first (fastest clear wins, score breaks ties). Pass scoreFirst=true
+// for FlawlessNES challenges, where the highest score (fewest hits) wins
+// and time only breaks ties. Exposed so it's testable.
+export function isBetterRun(a: RunMetric, b: RunMetric, scoreFirst = false): boolean {
   const at = a.completionTimeFrames ?? Infinity;
   const bt = b.completionTimeFrames ?? Infinity;
-  if (at !== bt) return at < bt;
   const as = a.score ?? -Infinity;
   const bs = b.score ?? -Infinity;
+  if (scoreFirst) {
+    if (as !== bs) return as > bs;
+    return at < bt;
+  }
+  if (at !== bt) return at < bt;
   return as > bs;
 }
 

--- a/tests/grading.test.ts
+++ b/tests/grading.test.ts
@@ -5,6 +5,8 @@ import {
   summarizeTrophies,
   emptyTrophyStats,
   GRADE_ORDER,
+  flawlessRankForScore,
+  flawlessHitsForScore,
   type Grade,
 } from '../src/lib/grading';
 
@@ -121,5 +123,39 @@ describe('emptyTrophyStats', () => {
       ssOrBetterPct: 0,
       attemptedPct: 0,
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FlawlessNES scoring (the fixed hit table — must mirror the challenge .lua)
+// ---------------------------------------------------------------------------
+describe('flawlessRankForScore', () => {
+  test('maps each table cutoff to its rank', () => {
+    expect(flawlessRankForScore(5000)).toBe('Flawless');
+    expect(flawlessRankForScore(3500)).toBe('A');
+    expect(flawlessRankForScore(2750)).toBe('B');
+    expect(flawlessRankForScore(2000)).toBe('C');
+    expect(flawlessRankForScore(1250)).toBe('D');
+    expect(flawlessRankForScore(93)).toBe('D');
+  });
+  test('null when no score', () => {
+    expect(flawlessRankForScore(null)).toBeNull();
+    expect(flawlessRankForScore(undefined)).toBeNull();
+  });
+});
+
+describe('flawlessHitsForScore', () => {
+  test('inverts the full published table exactly', () => {
+    // Hits → Score pairs straight from the FlawlessNES spec table.
+    const table: [number, number][] = [
+      [0, 5000], [1, 3500], [2, 2750], [3, 2000], [4, 1250],
+      [5, 1063], [6, 903], [7, 768], [10, 472], [20, 93],
+    ];
+    for (const [hits, score] of table) {
+      expect(flawlessHitsForScore(score)).toBe(hits);
+    }
+  });
+  test('null when no score', () => {
+    expect(flawlessHitsForScore(null)).toBeNull();
   });
 });

--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -118,6 +118,20 @@ describe('isBetterRun', () => {
     expect(isBetterRun({ score: 5000, completionTimeFrames: 100 },
                        { score: 5000, completionTimeFrames: 100 })).toBe(false);
   });
+
+  // FlawlessNES: score-first ranking (fewest hits wins; time breaks ties).
+  test('scoreFirst: higher score is better even if slower', () => {
+    expect(isBetterRun({ score: 5000, completionTimeFrames: 9999 },
+                       { score: 3500, completionTimeFrames: 100 }, true)).toBe(true);
+  });
+  test('scoreFirst: lower score is not better even if faster', () => {
+    expect(isBetterRun({ score: 2750, completionTimeFrames: 50 },
+                       { score: 5000, completionTimeFrames: 9999 }, true)).toBe(false);
+  });
+  test('scoreFirst: on score tie, faster time wins', () => {
+    expect(isBetterRun({ score: 5000, completionTimeFrames: 80 },
+                       { score: 5000, completionTimeFrames: 120 }, true)).toBe(true);
+  });
 });
 
 describe('windowSince', () => {


### PR DESCRIPTION
Adds the **FlawlessNES** challenge family to the leaderboard: no-hit runs ranked by **fewest hits** (rank labels Flawless/A/B/C/D), distinct from the existing time-ranked challenges.

## How it works
The desktop client submits the fixed-table **score** (5000→93), which is strictly monotonic in hits — so the board ranks by `score DESC` and recovers both the **rank label** and **hit count** from the score alone. **No DB migration**: the existing `(game, challengeName, score DESC, completionTimeFrames ASC)` index already serves the ranking.

## Changes
- **grading.ts** — `flawlessRankForScore` / `flawlessHitsForScore` (exact inverse of the published table) + rank-chip palette.
- **challenges-manifest.ts** — `flawlessnes` category + `isFlawlessCategory`; `MANIFEST_URL` env override for local testing.
- **leaderboard.ts** — score-first ordering (`runOrderBy` / `compareRuns`), `isBetterRun(scoreFirst)`; applied to the per-challenge board, recent-activity PB badges, profile best-run selection, and the submit-endpoint PB check.
- **UI** — dedicated FlawlessNES section on the catalog, per-game category section (via `CATEGORY_ORDER`), and Rank/Hits columns on the per-challenge page (instead of the time grade). Time-ranked challenges are unchanged.
- **tests** — +7 (rank + hits-from-score inverse vs the published table; score-first `isBetterRun`). 82 pass; `tsc --noEmit` clean.

## Pairs with
`retrochallenges-assets` — new challenge `nes/castlevania/flawlessnes-firstlevel/` with `"category": "flawlessnes"` (pushed to assets `main` after this deploys).

Verified end-to-end against the running app (isolated Postgres + local manifest): the flawless board ranks a faster 1-hit run **below** slower 0-hit runs; the time-ranked board is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)